### PR TITLE
Plugin for text message compose/address/send inside App. 

### DIFF
--- a/iPhone/SMSComposer/README.md
+++ b/iPhone/SMSComposer/README.md
@@ -1,0 +1,50 @@
+# PhoneGap SMSComposer #
+by Grant Sanders
+
+## Adding the Plugin to your project ##
+
+Using this plugin requires [PhoneGap for iPhone](http://github.com/phonegap/phonegap-iphone).
+
+1. Add the SMSComposer.h and SMSComposer.m files to your "Plugins" folder in your PhoneGap project
+2. Add the SMSComposer.js files to your "www" folder on disk, and add a reference to the .js file after phonegap.js.
+
+## RELEASE NOTES ##
+
+### 201101112 ###
+* Initial release
+* Adds SMS text message composition in-app.
+* Requires iOS 4.0 or higher. 
+  Attempts to compose SMS text without running 4.0+ fails gracefully with a friendly message.
+
+## EXAMPLE USAGE ##
+
+* All parameters are optional.
+window.plugins.smsComposer.showSMSComposer();
+
+
+* Passing phone number and message.
+window.plugins.smsComposer.showSMSComposer('3424221122', 'hello');
+
+* Multiple recipents are separated by comma(s).
+window.plugins.smsComposer.showSMSComposer('3424221122,2134463330', 'hello');
+
+
+* showSMSComposerWithCB takes a callback as its first parameter.  
+* 0, 1, 2, or 3 will be passed to the callback when the text message has been attempted.
+
+window.plugins.smsComposer.showSMSComposerWithCB(function(result){
+
+	if(result == 0)
+		alert("Cancelled");
+	else if(result == 1)
+		alert("Sent");
+	else if(result == 2)
+		alert("Failed.");
+	else if(result == 3)
+		alert("Not Sent.");		
+
+},'3424221122,2134463330', 'hello');
+
+
+* A fully working example as index.html has been added to this repository. 
+* It is an example of what your www/index.html could look like.

--- a/iPhone/SMSComposer/SMSComposer.h
+++ b/iPhone/SMSComposer/SMSComposer.h
@@ -1,0 +1,13 @@
+//
+//  SMSComposer.h
+//
+//  Created by Grant Sanders on 12/25/2010.
+
+
+#import <Foundation/Foundation.h>
+#import "PhoneGapCommand.h"
+@interface SMSComposer : PhoneGapCommand {
+}
+
+- (void)showSMSComposer:(NSArray*)arguments withDict:(NSDictionary*)options;
+@end

--- a/iPhone/SMSComposer/SMSComposer.js
+++ b/iPhone/SMSComposer/SMSComposer.js
@@ -1,0 +1,51 @@
+/**
+ * Clipboard plugin for PhoneGap
+ * window.plugins.SMSComposer
+ * 
+ * @constructor
+ */
+function SMSComposer()
+{
+	this.resultCallback = null;
+}
+
+SMSComposer.ComposeResultType =
+{
+Cancelled:0,
+Sent:1,
+Failed:2,
+NotSent:3
+}
+
+SMSComposer.prototype.showSMSComposer = function(toRecipients, body)
+{
+
+	var args = {};
+	
+	if(toRecipients)
+		args.toRecipients = toRecipients;
+	
+	if(body)
+		args.body = body;
+	
+	PhoneGap.exec("SMSComposer.showSMSComposer",args);
+}
+
+SMSComposer.prototype.showSMSComposerWithCB = function(cbFunction,toRecipients,body)
+{
+	this.resultCallback = cbFunction;
+	this.showSMSComposer.apply(this,[toRecipients,body]);
+}
+
+SMSComposer.prototype._didFinishWithResult = function(res)
+{
+	this.resultCallback(res);
+}
+
+PhoneGap.addConstructor(function() {
+						
+	if(!window.plugins)	{
+		window.plugins = {};
+	}
+	window.plugins.smsComposer = new SMSComposer();
+});

--- a/iPhone/SMSComposer/SMSComposer.m
+++ b/iPhone/SMSComposer/SMSComposer.m
@@ -1,0 +1,85 @@
+//
+//  ClipboardPlugin.m
+//  Clipboard plugin for PhoneGap
+//
+//  Created by Grant Sanders on 12/25/2010.
+//
+
+#import "SMSComposer.h"
+#import <MessageUI/MessageUI.h>
+#import <MessageUI/MFMessageComposeViewController.h>
+
+@implementation SMSComposer
+
+- (void)showSMSComposer:(NSArray*)arguments withDict:(NSDictionary*)options
+{
+	
+	Class messageClass = (NSClassFromString(@"MFMessageComposeViewController"));
+	if (messageClass != nil) {          
+		
+        if (![messageClass canSendText]) {
+			
+			UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Notice" message:@"SMS Text not available."
+														   delegate:self cancelButtonTitle:@"OK" otherButtonTitles: nil];
+			[alert show];
+			[alert release];
+			return;
+        }
+		
+    } else {
+		UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Notice" message:@"SMS Text not available."
+													   delegate:self cancelButtonTitle:@"OK" otherButtonTitles: nil];
+		[alert show];
+		[alert release];
+		return;
+	}
+	
+	
+	NSString* body = [options valueForKey:@"body"];
+	NSString* toRecipientsString = [options valueForKey:@"toRecipients"];
+	
+    MFMessageComposeViewController *picker = [[MFMessageComposeViewController alloc] init];
+    picker.messageComposeDelegate = self;
+	
+	if(body != nil)
+		picker.body = [options valueForKey:@"body"];
+	
+	if(toRecipientsString != nil)
+		[picker setRecipients:[ toRecipientsString componentsSeparatedByString:@","]];
+
+    [[ super appViewController ] presentModalViewController:picker animated:YES];
+    [picker release];
+	
+}
+
+// Dismisses the composition interface when users tap Cancel or Send. Proceeds to update the message field with the result of the operation.
+- (void)messageComposeViewController:(MFMessageComposeViewController *)controller didFinishWithResult:(MessageComposeResult)result
+{   
+    // Notifies users about errors associated with the interface
+	int webviewResult = 0;
+	
+	switch (result)
+	{
+		case MessageComposeResultCancelled:
+			webviewResult = 0;
+			break;
+		case MessageComposeResultSent:
+			webviewResult = 1;
+			break;
+		case MessageComposeResultFailed:
+			webviewResult = 2;
+			break;
+		default:
+			webviewResult = 3;
+			break;
+	}
+	
+    [[ super appViewController ] dismissModalViewControllerAnimated:YES];
+	
+	NSString* jsString = [[NSString alloc] initWithFormat:@"window.plugins.smsComposer._didFinishWithResult(%d);",webviewResult];
+	[self writeJavascript:jsString];
+	[jsString release];
+	
+}
+
+@end

--- a/iPhone/SMSComposer/index.html
+++ b/iPhone/SMSComposer/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+  <head>
+    <meta name="viewport" content="width=default-width; user-scalable=no" />
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+
+	<script type="text/javascript" charset="utf-8" src="phonegap.js"></script>
+
+	<script type="text/javascript" charset="utf-8" src="SMSComposer.js"></script>
+    <script type="text/javascript" charset="utf-8">
+	
+	function onBodyLoad()
+	{
+		document.addEventListener("deviceready",onDeviceReady,false);
+	}
+	function onDeviceReady()
+	{
+		viewUpdate();
+	}
+    </script>
+  </head>
+  <body onload="onBodyLoad()">
+
+
+<input onclick="ComposeSMS();" type="button" value="Compose SMS text with number and body" /><br />
+<input onclick="ComposeSMS2();" type="button" value="Compose SMS text with no parameters" /><br />
+<input onclick="ComposeSMS3();" type="button" value="Compose SMS text to multiple recipients" /><br />
+<input onclick="ComposeSMSWithCallback();" type="button" value="Compose SMS text with callback" />
+
+
+<script>
+
+var ComposeSMS = function(){
+
+	window.plugins.smsComposer.showSMSComposer('3424221122', 'hello');
+}
+
+var ComposeSMS2 = function(){
+
+	window.plugins.smsComposer.showSMSComposer();
+}
+
+var ComposeSMS3 = function(){
+
+	window.plugins.smsComposer.showSMSComposer('3424221122,2134463330', 'hello');
+}
+
+var ComposeSMSWithCallback = function(){
+
+	window.plugins.smsComposer.showSMSComposerWithCB(myCallback,'3424221122,2134463330', 'hello');
+}
+
+var myCallback = function(result){
+
+if(result == 0)
+	alert("Cancelled");
+else if(result == 1)
+	alert("Sent");
+else if(result == 2)
+	alert("Failed.");
+else if(result == 3)
+	alert("Not Sent.");		
+}
+
+</script>
+  </body>
+</html>
+


### PR DESCRIPTION
This PhoneGap plugin exposes MFMessageComposeViewController.  

Purpose is composing/addressing/sending text message(s) with recipient and message while inside app.  The user must press send, but this is all happens without leaving your app. This functionality was added when iOS 4.0 was released. 

This is similar in functionality, implementation, and usage as the EmailComposer plugin.
It has been implemented with the intention of using PhoneGap conventions, has been tested and working, and instructions are added.
