### PR TITLE
Update iOS Screenshot Plugin

### DIFF
--- a/iPhone/ScreenShot/ScreenShot.h
+++ b/iPhone/ScreenShot/ScreenShot.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <QuartzCore/QuartzCore.h>
 #import "PhoneGapCommand.h"
 @interface Screenshot : PhoneGapCommand {
 }


### PR DESCRIPTION
A fellow on IRC was getting the error `renderInContext no method found` when invoking the screenshot plugin.

I was able to replicate it and here is the fix.
