### PR TITLE
Mention StoreKit.framework dependency in iPhone/InAppPurchaseManager/READ

### DIFF
--- a/iPhone/InAppPurchaseManager/README.md
+++ b/iPhone/InAppPurchaseManager/README.md
@@ -5,7 +5,7 @@ Allows In-App Purchases to be made from Phonegap. Wraps StoreKit.
 
 ## Adding the Plugin to your project ##
 
-Copy the .h and .m file to the Plugins directory in your project. Copy the .js file to your www directory and reference it from your html file(s).
+Copy the .h and .m file to the Plugins directory in your project. Copy the .js file to your www directory and reference it from your html file(s). Finally, add StoreKit.framework to your Xcode project if you haven't already.
 
 
 ## Using the plugin ##


### PR DESCRIPTION
As a complete Objective-C/iOS/Xcode-Newby it took me some time to figure out my linking errors were caused by a missing dependency to the StoreKit.framework. It makes, of course, total sense, but I thought one might want to mention it in the README.

Thanks.
Tim
