### PR TITLE
Reset webview after dismissal

### DIFF
--- a/iPhone/ChildBrowser/ChildBrowserViewController.m
+++ b/iPhone/ChildBrowser/ChildBrowserViewController.m
@@ -94,6 +94,9 @@
 -(IBAction) onDoneButtonPress:(id)sender
 {
 	[ self closeBrowser];
+
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]];
+    [webView loadRequest:request];
 }
 
 


### PR DESCRIPTION
If you dismiss the web view and then open it again the previous page flashes out and is replaced by the new one. This simply navigates the uiwebview to about:blank after its dismissed so that the next time the view appears its empty until the page loads.
