### PR TITLE
add MIT license notice to iphone bundle file reader plugin

### DIFF
--- a/iPhone/BundleFileReader/BundleFileReader.h
+++ b/iPhone/BundleFileReader/BundleFileReader.h
@@ -1,5 +1,7 @@
 /**
- * @author Tim Fischbach <tfischbach@codevise.de>
+ * Bundle File Reader Plugin
+ * Copyright (c) 2011 Tim Fischbach (github.com/tf)
+ * MIT licensed
  */
 
 #ifdef PHONEGAP_FRAMEWORK

--- a/iPhone/BundleFileReader/BundleFileReader.m
+++ b/iPhone/BundleFileReader/BundleFileReader.m
@@ -1,5 +1,7 @@
 /**
- * @author Tim Fischbach <tfischbach@codevise.de>
+ * Bundle File Reader Plugin
+ * Copyright (c) 2011 Tim Fischbach (github.com/tf)
+ * MIT licensed
  */
 
 #import "BundleFileReader.h"

--- a/iPhone/BundleFileReader/README.md
+++ b/iPhone/BundleFileReader/README.md
@@ -2,8 +2,6 @@
 
 Read files from your app bundle.
 
-https://github.com/tf/phonegap-plugins
-
 ## Usage
 
 ```javascript
@@ -17,3 +15,15 @@ plugins.bundleFileReader.readResource(
   }
 );
 ```
+
+## License
+
+The MIT License
+
+Copyright (c) 2011 Tim Fischbach (github.com/tf)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/iPhone/BundleFileReader/bundle_file_reader.js
+++ b/iPhone/BundleFileReader/bundle_file_reader.js
@@ -1,5 +1,7 @@
 /**
- * @author Tim Fischbach <tfischbach@codevise.de>
+ * Bundle File Reader Plugin
+ * Copyright (c) 2011 Tim Fischbach (github.com/tf)
+ * MIT licensed
  */
 
 /*global plugins, PhoneGap*/


### PR DESCRIPTION
Moved the commit to a branch, which obviously reset my former pull request. So here it is again. Sorry.
