### PR TITLE
Share plugin for Android

### DIFF
--- a/Android/Share/README.md
+++ b/Android/Share/README.md
@@ -1,0 +1,40 @@
+# Share plugin for Android/Phonegap #
+By Kevin Schaul - @foxyNinja7
+
+## Using the plugin ##
+
+window.plugins.share.show({
+	subject: 'I like turtles',
+	text: 'http://www.mndaily.com'},
+	function() {},
+	function() {alert('Share failed')}
+);
+
+## Release notes ##
+
+### 7/11/2011 ###
+* Initial release
+
+## Licence ##
+
+The MIT License
+
+Copyright (c) 2011 Kevin Schaul
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Android/Share/README.md
+++ b/Android/Share/README.md
@@ -3,12 +3,12 @@ By Kevin Schaul - @foxyNinja7
 
 ## Using the plugin ##
 
-window.plugins.share.show({
-	subject: 'I like turtles',
-	text: 'http://www.mndaily.com'},
-	function() {},
-	function() {alert('Share failed')}
-);
+	window.plugins.share.show({
+		subject: 'I like turtles',
+		text: 'http://www.mndaily.com'},
+		function() {},
+		function() {alert('Share failed')}
+	);
 
 ## Release notes ##
 

--- a/Android/Share/Share.java
+++ b/Android/Share/Share.java
@@ -1,0 +1,40 @@
+/**
+ * 
+ * Phonegap share plugin for Android
+ * Kevin Schaul 2011
+ *
+ */
+
+package com.schaul.plugins.share;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import android.content.Intent;
+
+import com.phonegap.api.Plugin;
+import com.phonegap.api.PluginResult;
+
+public class Share extends Plugin {
+
+	@Override
+	public PluginResult execute(String action, JSONArray args, String callbackId) {
+		try {
+			JSONObject jo = args.getJSONObject(0);
+			doSendIntent(jo.getString("subject"), jo.getString("text")); 
+			return new PluginResult(PluginResult.Status.OK);
+		} catch (JSONException e) {
+			return new PluginResult(PluginResult.Status.JSON_EXCEPTION);
+		}
+	}
+	
+	private void doSendIntent(String subject, String text) {
+		Intent sendIntent = new Intent(android.content.Intent.ACTION_SEND);
+		sendIntent.setType("text/plain");
+		sendIntent.putExtra(android.content.Intent.EXTRA_SUBJECT, subject);
+		sendIntent.putExtra(android.content.Intent.EXTRA_TEXT, text);
+		this.ctx.startActivity(sendIntent);
+	}
+
+}

--- a/Android/Share/share.js
+++ b/Android/Share/share.js
@@ -1,0 +1,21 @@
+/**
+ * 
+ * Phonegap share plugin for Android
+ * Kevin Schaul 2011
+ *
+ */
+
+var Share = function() {};
+			
+Share.prototype.show = function(content, success, fail) {
+	return PhoneGap.exec( function(args) {
+		success(args);
+	}, function(args) {
+		fail(args);
+	}, 'Share', '', [content]);
+};
+
+PhoneGap.addConstructor(function() {
+	PhoneGap.addPlugin('share', new Share());
+	PluginManager.addService("Share","com.schaul.plugins.share.Share");
+});


### PR DESCRIPTION
This plugin taps into the built in Intent.ACTION_SEND, used widely in the Android system for sharing news stories, links, etc.
