### PR TITLE
Fixed a bug with hiding the Volume Slider

### DIFF
--- a/iPhone/VolumeSlider/VolumeSlider.m
+++ b/iPhone/VolumeSlider/VolumeSlider.m
@@ -72,10 +72,12 @@
 - (void)showVolumeSlider:(NSArray*)arguments withDict:(NSDictionary*)options
 {
 	self.myVolumeView.showsVolumeSlider = YES;
+	self.mpVolumeViewParentView.hidden = NO;
 }
 
 - (void)hideVolumeSlider:(NSArray*)arguments withDict:(NSDictionary*)options
 {
+	self.mpVolumeViewParentView.hidden = YES;
 	self.myVolumeView.showsVolumeSlider = NO;
 }
 


### PR DESCRIPTION
[Bug] Volume Slider's parent view was not hidden causing touch events to not get through when the Volume Slider was hidden
