### PR TITLE
Updates to the Android status bar plugin

### DIFF
--- a/Android/StatusBarNotification/README.md
+++ b/Android/StatusBarNotification/README.md
@@ -24,6 +24,14 @@ Using this plugin requires [Android PhoneGap](http://github.com/phonegap/phonega
 
     &lt;plugin name="StatusBarNotification" value="com.phonegap.plugins.statusBarNotification.StatusBarNotification"/&gt;
 
+5. You will need to add a nofication.png file to you applications res/drawable-ldpi, res/drawable-mdpi & res/drawable-hdpi directories.
+
+6. You will need to add an import line like:
+
+	import com.my.app.R; 
+	
+Where com.my.app is your applications package name in order for this to compile.
+
 ## Using the plugin ##
 
 The plugin creates the object `window.plugins.statusBarNotification`. To use, call one of the following, available methods:

--- a/Android/StatusBarNotification/StatusBarNotification.java
+++ b/Android/StatusBarNotification/StatusBarNotification.java
@@ -25,7 +25,7 @@
 *
 */
 
-package com.phonegap.plugins.statusBarNotification.StatusBarNotification;
+package com.phonegap.plugins.statusBarNotification;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -41,7 +41,7 @@ import com.phonegap.api.Plugin;
 import com.phonegap.api.PluginResult;
 import com.phonegap.api.PluginResult.Status;
 
-public class StatusBarNotificationPlugin extends Plugin {
+public class StatusBarNotification extends Plugin {
 	//	Action to execute
 	public static final String ACTION="notify";
 	

--- a/Android/StatusBarNotification/statusbarnotification.js
+++ b/Android/StatusBarNotification/statusbarnotification.js
@@ -37,7 +37,7 @@ var NotificationMessenger = function() {
  * @param body Body of the notification
  */
 NotificationMessenger.prototype.notify = function(title, body) {
-    return PhoneGap.exec(null, null, 'StatusBarNotificationPlugin',	'notify', [title, body]);
+    return PhoneGap.exec(null, null, 'StatusBarNotification',	'notify', [title, body]);
 };
 
 /**


### PR DESCRIPTION
I've made a few updates to the StatusBarNotification plugin. There was a mismatch of names between the package name, class name and reference to the class in the plugins.xml line in README.md. I standardized them all to be "StatusBarNotification".  Also, I added a note to the README to let people know they'd need to supply their own notification.png and update an import in order to get this to compile.
