### PR TITLE
WebIntent in Android: opening a file.

### DIFF
--- a/Android/Downloader/Downloader.java
+++ b/Android/Downloader/Downloader.java
@@ -1,0 +1,153 @@
+package com.phonegap.plugins.downloader;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import android.util.Log;
+
+import com.phonegap.api.Plugin;
+import com.phonegap.api.PluginResult;
+
+public class Downloader extends Plugin {
+
+	@Override
+	public PluginResult execute(String action, JSONArray args, String callbackId) {
+		
+		if (!action.equals("downloadFile")) 
+			return new PluginResult(PluginResult.Status.INVALID_ACTION);
+		
+		try {
+			
+			String fileUrl = args.getString(0);
+			JSONObject params = args.getJSONObject(1);
+			
+			String fileName = params.has("fileName") ? 
+					params.getString("fileName"):
+					fileUrl.substring(fileUrl.lastIndexOf("/")+1);
+			
+			String dirName = params.has("dirName") ?
+					params.getString("dirName"):
+					"sdcard/download";
+					
+			Boolean overwrite = params.has("overwrite") ? params.getBoolean("overwrite") : false;
+			
+			return this.downloadUrl(fileUrl, dirName, fileName, overwrite, callbackId);
+			
+		} catch (JSONException e) {
+
+			e.printStackTrace();
+			return new PluginResult(PluginResult.Status.JSON_EXCEPTION, e.getMessage());
+			
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+			return new PluginResult(PluginResult.Status.ERROR, e.getMessage());
+		}
+	
+	}
+
+	private PluginResult downloadUrl(String fileUrl, String dirName, String fileName, Boolean overwrite, String callbackId) throws InterruptedException, JSONException {
+		
+		try {
+			
+			Log.d("PhoneGapLog", "Downloading "+fileUrl + " into " + dirName + "/" + fileName);
+			
+			File dir = new File(dirName);
+			if (!dir.exists()) {
+				Log.d("PhoneGapLog", "directory " + dirName + " created");
+				dir.mkdirs();
+			}
+
+			File file = new File(dirName, fileName);
+
+			if (!overwrite && file.exists()) {
+				Log.d("DownloaderPlugin", "File already exist");
+				
+				JSONObject obj = new JSONObject();
+				obj.put("status", 1);
+				obj.put("total", 0);
+				obj.put("file", fileName);
+				obj.put("progress", 100);
+				
+				return new PluginResult(PluginResult.Status.OK, obj);
+			}
+
+			URL url = new URL(fileUrl);
+			HttpURLConnection ucon = (HttpURLConnection) url.openConnection();
+			ucon.setRequestMethod("GET");
+			ucon.setDoOutput(true);
+			ucon.connect();
+
+			Log.d("PhoneGapLog", "Download start");
+
+			InputStream is = ucon.getInputStream();
+			byte[] buffer = new byte[1024];
+			int readed = 0, 
+			    progress = 0,
+			    totalReaded = 0,
+			    fileSize = ucon.getContentLength();
+			
+			FileOutputStream fos = new FileOutputStream(file);
+
+			while ((readed = is.read(buffer)) > 0) {
+				
+				fos.write(buffer, 0, readed);
+				totalReaded += readed;
+				
+				int newProgress = (int) (totalReaded*100/fileSize);				
+				if (newProgress != progress)
+				 progress = informProgress(fileSize, newProgress, fileName, callbackId);
+
+			}
+
+			fos.close();
+
+			Log.d("PhoneGapLog", "Download finished");
+
+			JSONObject obj = new JSONObject();
+			obj.put("status", 1);
+			obj.put("total", fileSize);
+			obj.put("file", fileName);
+			obj.put("progress", progress);
+			
+			return new PluginResult(PluginResult.Status.OK, obj);
+			
+		}
+		catch (FileNotFoundException e) {
+			Log.d("PhoneGapLog", "File Not Found: " + e);
+			return new PluginResult(PluginResult.Status.ERROR, 404);
+		}
+		catch (IOException e) {
+			Log.d("PhoneGapLog", "Error: " + e);
+			return new PluginResult(PluginResult.Status.ERROR, e.getMessage());
+		}
+
+	}
+	
+	private int informProgress(int fileSize, int progress, String fileName, String callbackId) throws InterruptedException, JSONException {
+		
+		JSONObject obj = new JSONObject();
+		obj.put("status", 0);
+		obj.put("total", fileSize);
+		obj.put("file", fileName);
+		obj.put("progress", progress);
+		
+		PluginResult res = new PluginResult(PluginResult.Status.OK, obj);
+		res.setKeepCallback(true);
+		success(res, callbackId);
+		
+		//Give a chance for the progress to be sent to javascript
+		Thread.sleep(100);
+		
+		return progress; 
+	}
+
+}

--- a/Android/Downloader/README.md
+++ b/Android/Downloader/README.md
@@ -41,3 +41,7 @@ An example could be:
 	
 I will be happy to receive any comment, patch,  bug report or insult!
 
+
+## Reference ##
+
+http://www.toforge.com/2011/02/phonegap-android-plugin-for-download-files-from-url-on-sd-card/

--- a/Android/Downloader/README.md
+++ b/Android/Downloader/README.md
@@ -1,0 +1,40 @@
+# Downlaoder plugin for Phonegap #
+
+A plugin that downloads file from the web (http) to the device.
+
+## Adding the plugin to your project ##
+
+1. To install the plugin, move downloader.js to your project's www folder and include a reference to it in your html files. 
+2. Create a folder called 'com/phonegap/plugins/downloader' within your project's src/ folder.
+3. And copy the java file into that new folder.
+
+## Using the plugin ##
+
+The plugin creates the object `window.plugins.downloader` with one method `downloadFile(url, params, success, fail)`
+
+`url` is the url of the file to be downloaded. i.e. http://server/file.ext
+`params` is a json object containing optional parameters that Downloader accepts, it can be:
+ * dirName: Name of the directory to download the file to. By default "sdcard/download"
+ * fileName: Name of the file to be downloaded. By default the same as the one in `url`.
+ * overwrite: If the file already exists, download it again.
+ 
+`success` and `fail` are callback functions. Success will be called when there is a progress in the download. The passed object is:
+    {
+        status: 0,        //0 means progress, 1 means download is complete.
+        progress: 0,      //In percent
+        total: 1000,      //The total number of bytes to download.
+        file: "file.ext"  //Name of the file
+    }
+
+An example could be:
+
+    window.plugins.downloader.downloadFile("http://server/file.txt", {overwrite: true}, 
+	      function(res) {
+            alert(JSON.stringify(result));
+        }, function(error) {
+		    alert(error);
+	    }
+	);
+	
+I will be happy to receive any comment, patch,  bug report or insult!
+

--- a/Android/Downloader/README.md
+++ b/Android/Downloader/README.md
@@ -13,15 +13,18 @@ A plugin that downloads file from the web (http) to the device.
 The plugin creates the object `window.plugins.downloader` with one method `downloadFile(url, params, success, fail)`
 
 `url` is the url of the file to be downloaded. i.e. http://server/file.ext
+
 `params` is a json object containing optional parameters that Downloader accepts, it can be:
- * dirName: Name of the directory to download the file to. By default "sdcard/download"
- * fileName: Name of the file to be downloaded. By default the same as the one in `url`.
- * overwrite: If the file already exists, download it again.
+
+* dirName: Name of the directory to download the file to. By default "sdcard/download"
+* fileName: Name of the file to be downloaded. By default the same as the one in `url`.
+* overwrite: If the file already exists, download it again.
  
 `success` and `fail` are callback functions. Success will be called when there is a progress in the download. The passed object is:
+
     {
         status: 0,        //0 means progress, 1 means download is complete.
-        progress: 0,      //In percent
+        progress: 46,     //In percent
         total: 1000,      //The total number of bytes to download.
         file: "file.ext"  //Name of the file
     }

--- a/Android/Downloader/downloader.js
+++ b/Android/Downloader/downloader.js
@@ -1,0 +1,13 @@
+function Downloader() {}
+
+Downloader.prototype.downloadFile = function(fileUrl, params, win, fail) {
+	
+	//Make params hash optional.
+	if (!fail) win = params;
+	PhoneGap.exec(win, fail, "Downloader", "downloadFile", [fileUrl, params]);
+};
+
+PhoneGap.addConstructor(function() {
+	PhoneGap.addPlugin("downloader", new Downloader());
+	PluginManager.addService("Downloader", "com.phonegap.plugins.downloader.Downloader");
+});

--- a/Android/WebIntent/WebIntent.java
+++ b/Android/WebIntent/WebIntent.java
@@ -86,12 +86,17 @@ public class WebIntent extends Plugin {
 			return new PluginResult(PluginResult.Status.JSON_EXCEPTION);
 		}
 	}
-	
+
 	void startActivity(String action, Uri uri, String type, Map<String, String> extras) {
-		Intent i = (uri != null ? new Intent(action, uri) : new Intent(action));
-		if (type != null) {
-			i.setType(type);
-		}
+
+		Intent i = new Intent(action);
+		
+		if (uri!=null)
+			if (type!=null)
+				i.setDataAndType(uri, type);
+			else
+				i.setData(uri);
+		
 		for (String key : extras.keySet()) {
 			String value = extras.get(key);
 			i.putExtra(key, value);


### PR DESCRIPTION
Somehow, when setting the type after instancing the Intent object doesn't work as expected.
When using setDataAndType, it does work ok.

Maybe its something else, im no expert!!.. :)

Im using it like this: 

```
 window.plugins.webintent.startActivity({
    action: WebIntent.ACTION_VIEW,
    type: "application/pdf",
    url: "/mnt/sdcard/download/file.pdf"},
      function() {},
      function() {}
      );
```

Thanks!!
