### PR TITLE
Uncovered (and fixed) a masked bug

### DIFF
--- a/iPhone/MapKitPlug/src/MapKit.m
+++ b/iPhone/MapKitPlug/src/MapKit.m
@@ -13,7 +13,7 @@
 	#import <PhoneGap/SBJSON.h>
 #else
 	#import "SBJsonParser.h"
-	#import "SBJSON.h
+	#import "SBJSON.h"
 #endif
 
 @implementation MapKitView
@@ -154,8 +154,6 @@
 	
 	
 	SBJSON *parser=[[SBJSON alloc] init];
-	NSArray *pins = [parser objectWithString:[arguments objectAtIndex:0]];
-#pragma unused(pins)
 	[parser autorelease];
 	CGRect webViewBounds = self.webView.bounds;
 	


### PR DESCRIPTION
While working on this pull request:
https://github.com/phonegap/phonegap-iphone/pull/220

I uncovered a bug in the MapKit plugin. setMapData was requesting argument 0 and then not using it. Argument 0 should not have existed since it was never passed, but a bug/feature in the InvokedUrlCommand code always passes an array with at least 1 empty string entry for the arguments list.

This pull request fixes the problem in MapKit.
