### PR TITLE
WebIntent in Android: opening a file. 

### DIFF
--- a/Android/WebIntent/WebIntent.java
+++ b/Android/WebIntent/WebIntent.java
@@ -86,12 +86,17 @@ public class WebIntent extends Plugin {
 			return new PluginResult(PluginResult.Status.JSON_EXCEPTION);
 		}
 	}
-	
+
 	void startActivity(String action, Uri uri, String type, Map<String, String> extras) {
-		Intent i = (uri != null ? new Intent(action, uri) : new Intent(action));
-		if (type != null) {
-			i.setType(type);
-		}
+
+		Intent i = new Intent(action);
+		
+		if (uri!=null)
+			if (type!=null)
+				i.setDataAndType(uri, type);
+			else
+				i.setData(uri);
+		
 		for (String key : extras.keySet()) {
 			String value = extras.get(key);
 			i.putExtra(key, value);


### PR DESCRIPTION
Use setDataAndType to let open a file with a type.

Somehow, when setting the type after instancing the Intent object doesn't work as expected.
When using setDataAndType, it does work ok.

Maybe its something else, im no expert!!.. :)

Im using it like this:

  window.plugins.webintent.startActivity({
    action: WebIntent.ACTION_VIEW,
    type: "application/pdf",
    url: "/mnt/sdcard/download/file.pdf"},
      function() {},
      function() {}
   );

Thanks!!
