### PR TITLE
Changed the way the Locale is retrieved in Android

### DIFF
--- a/Android/Globalization/GlobalizationCommand.java
+++ b/Android/Globalization/GlobalizationCommand.java
@@ -86,7 +86,7 @@ public class GlobalizationCommand extends Plugin  {
 		JSONObject obj = new JSONObject();
 		String value = null;		
 		try{			
-			value = Locale.getDefault().getDisplayName(); //get the locale from the Android Device
+			value = Locale.getDefault().toString(); //get the locale from the Android Device
 			obj.put("value",value);		
 			return obj;		
 		}catch(Exception e){


### PR DESCRIPTION
On Android, the method getLocaleName was returning a readable string instead of the language code (something like en_GB). On iOS it was returning the actual code, so I figured it was a bug. 
