### PR TITLE
AudioEncode Plugin. Easily Convert WAVs to M4As.

### DIFF
--- a/iPhone/AudioEncode/AudioEncode.h
+++ b/iPhone/AudioEncode/AudioEncode.h
@@ -1,0 +1,25 @@
+//
+//  AudioEncode.h
+//
+//  By Lyle Pratt, September 2011.
+//  MIT licensed
+//
+
+#import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
+#ifdef PHONEGAP_FRAMEWORK
+    #import <PhoneGap/PGPlugin.h>
+#else
+    #import "PGPlugin.h"
+#endif
+
+@interface AudioEncode : PGPlugin {
+    NSString* successCallback;
+    NSString* failCallback;
+}
+
+@property (nonatomic, retain) NSString* successCallback;
+@property (nonatomic, retain) NSString* failCallback;
+
+- (void)encodeAudio:(NSArray*)arguments withDict:(NSDictionary*)options;
+@end

--- a/iPhone/AudioEncode/AudioEncode.js
+++ b/iPhone/AudioEncode/AudioEncode.js
@@ -1,0 +1,26 @@
+//
+//  AudioEncode.js
+//
+//  Created by Lyle Pratt, September 2011.
+//  MIT licensed
+//
+
+/**
+ * This class converts audio at a file path to M4A format
+ * @constructor
+ */
+function AudioEncode() {
+}
+
+AudioEncode.prototype.encodeAudio = function(audioPath, successCallback, failCallback) {
+    PhoneGap.exec("AudioEncode.encodeAudio", audioPath, GetFunctionName(successCallback), GetFunctionName(failCallback));
+};
+
+PhoneGap.addConstructor(function()
+{
+	if(!window.plugins)
+	{
+		window.plugins = {};
+	}
+    window.plugins.AudioEncode = new AudioEncode();
+});

--- a/iPhone/AudioEncode/AudioEncode.m
+++ b/iPhone/AudioEncode/AudioEncode.m
@@ -1,0 +1,74 @@
+//
+//  AudioEncode.m
+//
+//  By Lyle Pratt, September 2011.
+//  MIT licensed
+//
+
+#import "AudioEncode.h"
+
+@implementation AudioEncode
+
+@synthesize successCallback, failCallback;
+
+- (void)encodeAudio:(NSArray*)arguments withDict:(NSDictionary*)options
+{
+    self.successCallback = [[arguments objectAtIndex:1] retain];
+    self.failCallback = [[arguments objectAtIndex:2] retain];
+	NSString* audioPath = [arguments objectAtIndex:0];
+    
+	NSURL* audioURL = [NSURL fileURLWithPath:audioPath];
+	AVURLAsset* audioAsset = [[AVURLAsset alloc] initWithURL:audioURL options:nil];
+    AVAssetExportSession* exportSession = [[AVAssetExportSession alloc] initWithAsset:audioAsset presetName:AVAssetExportPresetAppleM4A];
+	
+	NSURL* exportURL = [NSURL fileURLWithPath:[[audioPath componentsSeparatedByString:@".wav"] objectAtIndex:0]];
+	NSURL* destinationURL = [exportURL URLByAppendingPathExtension:@"m4a"];
+
+    exportSession.outputURL = destinationURL;
+	exportSession.outputFileType = AVFileTypeAppleM4A;
+	
+    [exportSession exportAsynchronouslyWithCompletionHandler:^{
+    
+        if (AVAssetExportSessionStatusCompleted == exportSession.status) {
+            NSLog(@"AVAssetExportSessionStatusCompleted");
+            [self performSelectorOnMainThread:@selector(doSuccessCallback:) withObject:[exportSession.outputURL path] waitUntilDone:NO];
+        } else if (AVAssetExportSessionStatusFailed == exportSession.status) {
+            // a failure may happen because of an event out of your control
+            // for example, an interruption like a phone call comming in
+            // make sure and handle this case appropriately
+            NSLog(@"AVAssetExportSessionStatusFailed");
+            [self performSelectorOnMainThread:@selector(doFailCallback:) withObject:[NSString stringWithFormat:@"%i", exportSession.status] waitUntilDone:NO];
+            
+        } else {
+            NSLog(@"Export Session Status: %d", exportSession.status);
+        }
+        
+        [exportSession release];
+    }];
+    
+	
+    NSFileManager *fileMgr = [NSFileManager defaultManager];
+    NSError *error = noErr;
+	if ([fileMgr removeItemAtPath:audioPath error:&error] != YES) {
+		NSLog(@"Unable to delete file: %@", [error localizedDescription]);
+    }
+    
+}
+
+
+
+-(void) doSuccessCallback:(NSString*)path {
+    NSLog(@"doing success callback");
+    NSString* jsCallback = [NSString stringWithFormat:@"%@(\"%@\");", self.successCallback, path];
+    [self writeJavascript: jsCallback];
+    [self.successCallback release];
+}
+
+-(void) doFailCallback:(NSString*)status {
+    NSLog(@"doing fail callback");
+    NSString* jsCallback = [NSString stringWithFormat:@"%@(\"%@\");", self.failCallback, status];
+    [self writeJavascript: jsCallback];
+    [self.failCallback release];
+}
+
+@end

--- a/iPhone/AudioEncode/README.md
+++ b/iPhone/AudioEncode/README.md
@@ -1,0 +1,43 @@
+## PhoneGap AudioEncode Plugin ##
+by Lyle Pratt
+
+## About this Plugin ##
+
+This plugin lets you easily convert WAV audio into M4A audio. It is useful when using Phonegap's audio capture or media recording functionality. Uploading WAV files on via cellular connections is not advised.  M4A encoded files are about 1/4 the size.
+
+## Using the Plugin ##
+
+The plugin creates the object `window.plugins.AudioEncode` with one method `encodeAudio(pathToWavFile, success, fail)`. All parameters are required and it will crash if they are not included. The plugin will encode and save the audio in the same directory the WAV audio was in, then delete the WAV file on completion. If you encode `festMonkey.wav`, you'll get `festMonkey.m4a`.
+
+		window.plugins.AudioEncode.encodeAudio(pathToWavFile, success, fail);
+
+		var success = function(newM4APath) {
+			//Do something with your new encoded audio (upload it?)
+			console.log(newM4APath);
+		}
+
+		var fail = function(statusCode) {
+			//Why did it fail?
+			console.log(statusCode);
+		}
+
+## Adding the Plugin to your project ##
+
+Using this plugin requires [iPhone PhoneGap](http://github.com/phonegap/phonegap-iphone).
+
+1. Make sure your PhoneGap Xcode project has been updated.
+2. Add the .h and .m files to your Plugins folder in your project.
+3. Add the .js files to your "www" folder on disk, and add reference(s) to the .js files in your html file(s).
+
+## LICENSE ##
+
+The MIT License
+
+Copyright (c) 2011 Lyle Pratt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+


### PR DESCRIPTION
AudioEncode iOS plugin. This plugin lets you easily convert WAV files to M4A files. Give it a path to a WAV file, and it splits out a path to a M4A file.
