### PR TITLE
Plugin that Extend's Phonegap's iOS Audio Recording Functions to Accept Encoding, Bitrate, Sampling, and Channels

### DIFF
--- a/iPhone/AudioRecord/AudioRecord.h
+++ b/iPhone/AudioRecord/AudioRecord.h
@@ -1,0 +1,26 @@
+//
+//  AudioRecord.h
+//
+//  By Lyle Pratt, September 2011.
+//  MIT licensed
+//
+
+#import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
+#import <AudioToolbox/AudioServices.h>
+
+#ifdef PHONEGAP_FRAMEWORK
+    #import <PhoneGap/PGPlugin.h>
+    #import <PhoneGap/Sound.h>
+#else
+    #import "PGPlugin.h"
+    #import "Sound.h"
+#endif
+
+@interface AudioRecord : PGSound <AVAudioRecorderDelegate> {
+}
+
+- (void)startAudioRecord:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+- (void) stopAudioRecord:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+
+@end

--- a/iPhone/AudioRecord/AudioRecord.js
+++ b/iPhone/AudioRecord/AudioRecord.js
@@ -1,0 +1,24 @@
+//
+//  AudioRecord.js
+//
+//  Created by Lyle Pratt, September 2011.
+//  MIT licensed
+//
+
+/**
+ * PhoneGap's provided media library does not let you provide settings to the recording process
+ * resulting in large, stereo files of a specific, unchangable bitrate and sampling rate. These
+ * functions are intended to remedy that.
+ * @constructor
+ */
+ 
+/**
+ * Start recording audio file.
+ */
+Media.prototype.startRecordWithSettings = function(options) {
+    PhoneGap.exec(null, null, "AudioRecord","startAudioRecord", [this.id, this.src, options]);
+};
+
+Media.prototype.stopRecordWithSettings = function() {
+    PhoneGap.exec(null, null, "AudioRecord","stopAudioRecord", [this.id, this.src]);
+};

--- a/iPhone/AudioRecord/AudioRecord.m
+++ b/iPhone/AudioRecord/AudioRecord.m
@@ -1,0 +1,134 @@
+//
+//  AudioRecord.m
+//
+//  By Lyle Pratt, September 2011.
+//  MIT licensed
+//
+
+#import "AudioRecord.h"
+
+@implementation AudioRecord
+
+- (void) startAudioRecord:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options {
+	NSString* callbackId = [arguments objectAtIndex:0];
+#pragma unused(callbackId)
+	
+	NSString* mediaId = [arguments objectAtIndex:1];
+    
+    //Use Super's audio file.
+	PGAudioFile* audioFile = [super audioFileForResource:[arguments objectAtIndex:2] withId: mediaId];
+    NSString* jsString = nil;
+    
+    NSString* FormatIDString = [options objectForKey:@"FormatID"];
+    
+    //Default is LinearPCM
+    NSNumber* FormatID = [NSNumber numberWithInt:kAudioFormatLinearPCM];
+    
+    if(FormatIDString == @"kAudioFormatLinearPCM") {
+        FormatID = [NSNumber numberWithInt:kAudioFormatLinearPCM];
+    }
+    else if(FormatIDString == @"kAudioFormatAppleLossless") {
+        FormatID = [NSNumber numberWithInt:kAudioFormatAppleLossless];
+    }
+    else if(FormatIDString == @"kAudioFormatAppleIMA4") {
+        FormatID = [NSNumber numberWithInt:kAudioFormatAppleIMA4];
+    }
+    else if(FormatIDString == @"kAudioFormatiLBC") {
+        FormatID = [NSNumber numberWithInt:kAudioFormatiLBC];
+    }
+    else if(FormatIDString == @"kAudioFormatULaw") {
+        FormatID = [NSNumber numberWithInt:kAudioFormatULaw];
+    }
+    else if(FormatIDString == @"kAudioFormatALaw") {
+        FormatID = [NSNumber numberWithInt:kAudioFormatALaw];
+    }
+    
+    
+    NSNumber* SampleRate = [options objectForKey:@"SampleRate"];
+    NSNumber* NumberOfChannels = [options objectForKey:@"NumberOfChannels"];
+    NSNumber* LinearPCMBitDepth = [options objectForKey:@"LinearPCMBitDepth"];
+    
+	if (audioFile != nil) {
+		
+		NSError* error = nil;
+
+		if (audioFile.recorder != nil) {
+			[audioFile.recorder stop];
+			audioFile.recorder = nil;
+		}
+        
+        NSDictionary* recorderSettingsDict = [[NSDictionary alloc] initWithObjectsAndKeys:
+                        FormatID,AVFormatIDKey,
+                        SampleRate,AVSampleRateKey,
+                        NumberOfChannels,AVNumberOfChannelsKey,
+                        LinearPCMBitDepth,AVLinearPCMBitDepthKey,
+                        [NSNumber numberWithInt:0],AVLinearPCMIsBigEndianKey,
+                        [NSNumber numberWithInt:0],AVLinearPCMIsFloatKey,
+                        nil];
+        
+        
+		// create a new recorder for each start record
+		audioFile.recorder = [[AudioRecorder alloc] initWithURL:audioFile.resourceURL settings:recorderSettingsDict error:&error];
+	
+		if (error != nil) {
+			NSLog(@"Failed to initialize AVAudioRecorder: %@\n", error);
+			audioFile.recorder = nil;
+			jsString = [NSString stringWithFormat: @"%@(\"%@\",%d,%d);", @"PhoneGap.Media.onStatus", mediaId, MEDIA_ERROR, MEDIA_ERR_ABORTED];
+			
+		} else {
+			audioFile.recorder.delegate = self;
+			audioFile.recorder.mediaId = mediaId;
+			[audioFile.recorder record];
+			NSLog(@"Started recording audio sample '%@'", audioFile.resourcePath);
+            jsString = [NSString stringWithFormat: @"%@(\"%@\",%d,%d);", @"PhoneGap.Media.onStatus", mediaId, MEDIA_STATE, MEDIA_RUNNING];
+		}
+	}
+    if (jsString) {
+       [super writeJavascript:jsString]; 
+    }
+	return;
+}
+
+- (void) stopAudioRecord:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options {
+	NSString* callbackId = [arguments objectAtIndex:0];
+#pragma unused(callbackId)
+	NSString* mediaId = [arguments objectAtIndex:1];
+
+    //Use Super's soundCache
+	PGAudioFile* audioFile = [[super soundCache] objectForKey: [arguments objectAtIndex:2]];
+    NSString* jsString = nil;
+	
+	if (audioFile != nil && audioFile.recorder != nil) {
+		NSLog(@"Stopped recording audio sample '%@'", audioFile.resourcePath);
+		[audioFile.recorder stop];
+        jsString = [NSString stringWithFormat: @"%@(\"%@\",%d,%d);", @"PhoneGap.Media.onStatus", mediaId, MEDIA_STATE, MEDIA_STOPPED];
+	} else {
+        jsString = [NSString stringWithFormat: @"%@(\"%@\",%d,%d);", @"PhoneGap.Media.onStatus", mediaId, MEDIA_ERROR, MEDIA_NONE];
+    }
+    if (jsString) {
+        [super writeJavascript:jsString]; 
+    }
+}
+
+- (void)audioRecorderDidFinishRecording:(AVAudioRecorder*)recorder successfully:(BOOL)flag {
+
+	AudioRecorder* aRecorder = (AudioRecorder*)recorder;
+	NSString* mediaId = aRecorder.mediaId;
+    
+    //Use Super's soundCache
+	PGAudioFile* audioFile = [[super soundCache] objectForKey: [aRecorder.url path]]; //mediaId];
+	NSString* jsString = nil;
+
+	
+	if (audioFile != nil) {
+		NSLog(@"Finished recording audio sample '%@'", audioFile.resourcePath);
+		if (flag){
+			jsString = [NSString stringWithFormat: @"%@(\"%@\",%d,%d);", @"PhoneGap.Media.onStatus", mediaId, MEDIA_STATE, MEDIA_STOPPED];
+		} else {
+			jsString = [NSString stringWithFormat: @"%@(\"%@\",%d,%d);", @"PhoneGap.Media.onStatus", mediaId, MEDIA_ERROR, MEDIA_ERR_DECODE];
+		}
+		[super writeJavascript:jsString];
+	}
+}
+
+@end

--- a/iPhone/AudioRecord/README.md
+++ b/iPhone/AudioRecord/README.md
@@ -1,0 +1,40 @@
+## PhoneGap AudioRecord Plugin ##
+by Lyle Pratt
+
+## About this Plugin ##
+
+PhoneGap's media library does not let you provide settings to the audio recording functionality resulting in large, stereo files of a specific, unchangeable bitrate and sampling rate. These functions are intended to remedy that.
+
+## Using the Plugin ##
+
+The plugin adds two methods to Phonegap's existing media class: `media.startRecordWithSettings(options)` and `media.stopRecordWithSettings`. You must include all of the encoding options listed in the example or it will crash. The plugin will allows you to pass a FormatID, SampleRate, NumberOfChannels, and LinearPCMBitDepth to the record function.
+
+		var recordSettings = {
+                	"FormatID": "kAudioFormatULaw",
+                        "SampleRate": 8000.0,
+                        "NumberOfChannels": 1,
+                        "LinearPCMBitDepth": 16
+                }
+		media.startRecordWithSettings(recordSettings);
+		media.stopRecordWithSettings();
+
+## Adding the Plugin to your project ##
+
+Using this plugin requires [iPhone PhoneGap](http://github.com/phonegap/phonegap-iphone).
+
+1. Make sure your PhoneGap Xcode project has been updated.
+2. Add the .h and .m files to your Plugins folder in your project.
+3. Add the .js files to your "www" folder on disk, and add reference(s) to the .js files in your html file(s).
+
+## LICENSE ##
+
+The MIT License
+
+Copyright (c) 2011 Lyle Pratt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+


### PR DESCRIPTION
Added an AudioRecord plugin that lets you pass settings to the Phonegap audio record functionality.

PhoneGap's media library does not let you provide settings to the audio recording functionality resulting in large, stereo files of a specific, unchangeable bitrate and sampling rate. These functions are intended to remedy that.

The plugin adds two methods to Phonegap's existing media class: `media.startRecordWithSettings(options)` and `media.stopRecordWithSettings`. You must include all of the encoding options listed in the example or it will crash. The plugin will allows you to pass a FormatID, SampleRate, NumberOfChannels, and LinearPCMBitDepth to the record function.
