### PR TITLE
Changed parseInt to parseFloat

### DIFF
--- a/iPhone/DatePicker/DatePicker.js
+++ b/iPhone/DatePicker/DatePicker.js
@@ -32,7 +32,7 @@ if (typeof PhoneGap !== "undefined") {
     }
 
     DatePicker.prototype._dateSelected = function(date) {
-        var d = new Date(parseInt(date)*1000);
+        var d = new Date(parseFloat(date)*1000);
         if (this._callback)
             this._callback(d);
     }


### PR DESCRIPTION
Changed parseInt to parseFloat. ParseInt was breaking because you didn't specify a radix.
