### PR TITLE
Fix "Class not found" error message from Phonegap

### DIFF
--- a/Android/Globalization/README.md
+++ b/Android/Globalization/README.md
@@ -14,7 +14,7 @@ Using this plugin requires [Android PhoneGap](http://github.com/phonegap/phonega
 
 3. In your res/xml/plugins.xml file add the following line:
 
-    &lt;plugin name="Globalization" value="com.phonegap.plugins.globalization.GlobalizationCommand"/&gt;
+    &lt;plugin name="GlobalizationCommand" value="com.phonegap.plugins.globalization.GlobalizationCommand"/&gt;
 
 
 ## RELEASE NOTES ##


### PR DESCRIPTION
Fixed plugin name in section 3 because Phonegap returns a "Class not found" error message
