### PR TITLE
Fix for broken plugin callback in BarcodeScanner iOS plugin in phonegap 1.1.0

### DIFF
--- a/iPhone/BarcodeScanner/barcodescanner.js
+++ b/iPhone/BarcodeScanner/barcodescanner.js
@@ -7,6 +7,9 @@ var BarcodeScanner = function() {
 
 }
 
+BarcodeScanner.prototype.callbackMap = {};
+BarcodeScanner.prototype.callbackIdx = 0;
+
 /* That's your lot for the moment */
 
 BarcodeScanner.Type = {
@@ -16,11 +19,26 @@ BarcodeScanner.Type = {
 /* Types are ignored at the moment until I implement any other than QR Code */
 
 BarcodeScanner.prototype.scan = function(types, success, fail) {
-    return PhoneGap.exec("BarcodeScanner.scan", GetFunctionName(success), GetFunctionName(fail), types);
+    
+    var plugin = window.plugins.barcodeScanner,
+        cbMap = plugin.callbackMap,
+        key = 'scan' + plugin.callbackIdx++;
+    
+    cbMap[key] = {
+        success: function(result) {
+            delete cbMap[key];
+            success(result);
+        },
+        fail: function(result) {
+            delete cbMap[key];
+            fail(result);
+        }
+    };
+        
+    var cbPrefix = 'window.plugins.barcodeScanner.callbackMap.' + key;
+    
+    return PhoneGap.exec("BarcodeScanner.scan", cbPrefix + ".success", cbPrefix + ".fail", types);
 };
-
-
-
 
 PhoneGap.addConstructor(function() 
 {


### PR DESCRIPTION
Since GetFunctionName was removed in https://github.com/shazron/phonegap-iphone/commit/5544b2a0664ae2714ec1df2b6e16aa97d3cfa9bc the BarcodePlugin stopped working. I've taken a note from the InAppPurchaseManager plugin and created a plugin map with proper disposal of callback methods.
