### PR TITLE
Add note about listing subdomains in whitelist

### DIFF
--- a/iPhone/ChildBrowser/README.txt
+++ b/iPhone/ChildBrowser/README.txt
@@ -1,6 +1,3 @@
-
-
-
 The child browser allows you to display external webpages within your PhoneGap application.
 
 A simple use case would be:
@@ -66,6 +63,22 @@ Sample use:
 		alert("In index.html onOpenExternal");
 	}
 </code>
+
+================================
+
+Oct 6, 2011
+
+SubDomains must be listed individually.
+
+EXAMPLE:
+
+geoiplookup.wikimedia.org
+meta.wikimedia.org
+wikipedia.org
+upload.wikimedia.org
+
+================================ @RandyMcMillan
+
 
 
 


### PR DESCRIPTION
If images are located under a different subdomain than the primary document Child Browser is unable to load and display the images without the relevant subdomain being included in the whitelist.
