### PR TITLE
iOS ClipboardPlugin: support for special characters added

### DIFF
--- a/iPhone/ClipboardPlugin/ClipboardPlugin.m
+++ b/iPhone/ClipboardPlugin/ClipboardPlugin.m
@@ -26,10 +26,13 @@
 	UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
 	NSString     *jsCallback = [arguments objectAtIndex:0];
 
-	NSString *text = [pasteboard valueForPasteboardType:@"public.utf8-plain-text"];
+	NSString *text = [[[[pasteboard valueForPasteboardType:@"public.utf8-plain-text"] 
+                       stringByReplacingOccurrencesOfString:@"\n" withString:@"\\n"] 
+                       stringByReplacingOccurrencesOfString:@"\r" withString:@"\\r"] 
+                       stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""];
   
-  NSString* jsString = [[NSString alloc] initWithFormat:@"%@(\"%@\");", jsCallback, text];
-  [self writeJavascript:jsString];
+    NSString* jsString = [[NSString alloc] initWithFormat:@"%@(\"%@\");", jsCallback, text];
+    [self writeJavascript:jsString];
   
 	[jsString release];
 }

--- a/iPhone/ClipboardPlugin/ClipboardPlugin.m
+++ b/iPhone/ClipboardPlugin/ClipboardPlugin.m
@@ -8,8 +8,10 @@
 #import <Foundation/Foundation.h>
 #ifdef PHONEGAP_FRAMEWORK
 #import <PhoneGap/PGPlugin.h>
+#import <PhoneGap/PluginResult.h>
 #else
 #import "PGPlugin.h"
+#import "PluginResult.h"
 #endif
 #import "ClipboardPlugin.h"
 
@@ -19,22 +21,18 @@
 	UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
 	NSString     *text       = [arguments objectAtIndex:0];
 
-	[pasteboard setValue:text forPasteboardType:@"public.utf8-plain-text"];
+	[pasteboard setValue:text forPasteboardType:@"public.text"];
 }
 
 -(void)getText:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options {
+    NSString* callbackID = [arguments pop];
 	UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
-	NSString     *jsCallback = [arguments objectAtIndex:0];
 
-	NSString *text = [[[[pasteboard valueForPasteboardType:@"public.utf8-plain-text"] 
-                       stringByReplacingOccurrencesOfString:@"\n" withString:@"\\n"] 
-                       stringByReplacingOccurrencesOfString:@"\r" withString:@"\\r"] 
-                       stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""];
+	NSString *text = [pasteboard valueForPasteboardType:@"public.text"];
+    
+    PluginResult* pluginResult = [PluginResult resultWithStatus:PGCommandStatus_OK messageAsString:text];
   
-    NSString* jsString = [[NSString alloc] initWithFormat:@"%@(\"%@\");", jsCallback, text];
-    [self writeJavascript:jsString];
-  
-	[jsString release];
+    [self writeJavascript: [pluginResult toSuccessCallbackString:callbackID]];
 }
 
 @end

--- a/iPhone/ClipboardPlugin/README.md
+++ b/iPhone/ClipboardPlugin/README.md
@@ -8,6 +8,8 @@ Using this plugin requires [PhoneGap for iPhone](http://github.com/phonegap/phon
 1. Add the ClipboardPlugin.h and ClipboardPlugin.m files to your "Plugins" folder in your PhoneGap project
 2. Add the clipboardPlugin.js files to your "www" folder on disk, and add a reference to the .js file as <link> tags in your html file(s)
 
+This plugin supports copying and pasting only text and no other data types right now, as it uses the Uniform Type Identifier public.text, but it could be extended to work with any UTI, e.g. by passing the type as optional parameter.
+
 ## RELEASE NOTES ##
 
 ### 20101223 ###

--- a/iPhone/ClipboardPlugin/clipboardPlugin.js
+++ b/iPhone/ClipboardPlugin/clipboardPlugin.js
@@ -24,7 +24,7 @@ ClipboardPlugin.prototype.setText = function(text)
  */
 ClipboardPlugin.prototype.getText = function(callback)
 {
-	PhoneGap.exec("ClipboardPlugin.getText", callback);
+	PhoneGap.exec(callback, null, "ClipboardPlugin", "getText", []);
 }
 
 /**

--- a/iPhone/ClipboardPlugin/clipboardPlugin.js
+++ b/iPhone/ClipboardPlugin/clipboardPlugin.js
@@ -24,7 +24,7 @@ ClipboardPlugin.prototype.setText = function(text)
  */
 ClipboardPlugin.prototype.getText = function(callback)
 {
-	PhoneGap.exec("ClipboardPlugin.getText", GetFunctionName(callback));
+	PhoneGap.exec("ClipboardPlugin.getText", callback);
 }
 
 /**


### PR DESCRIPTION
Discovered that newlines and backslashes in clipboard text cause an error and fixed it.
