### PR TITLE
Add callback handlers for restoreCompletedTransactions of ios in app purc

### DIFF
--- a/iPhone/InAppPurchaseManager/InAppPurchaseManager.h
+++ b/iPhone/InAppPurchaseManager/InAppPurchaseManager.h
@@ -31,6 +31,8 @@
 - (void) requestProductData:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
 - (void) requestProductsData:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
 - (void) paymentQueue:(SKPaymentQueue *)queue updatedTransactions:(NSArray *)transactions;
+- (void) paymentQueue:(SKPaymentQueue *)queue restoreCompletedTranactionsFailedWithError:(NSError *)error;
+- (void) paymentQueueRestoreCompletedTransactionsFinished:(SKPaymentQueue *)queue;
 
 @end
 

--- a/iPhone/InAppPurchaseManager/InAppPurchaseManager.js
+++ b/iPhone/InAppPurchaseManager/InAppPurchaseManager.js
@@ -102,6 +102,11 @@ InAppPurchaseManager.prototype.onRestored = null;
 /* function(errorCode, errorText) */
 InAppPurchaseManager.prototype.onFailed = null;
 
+/* function() */
+InAppPurchaseManager.prototype.onRestoreCompletedTransactionsFinished = null;
+
+/* function(errorCode) */
+InAppPurchaseManager.prototype.onRestoreCompletedTransactionsFailed = null;
 
 /* This is called from native.*/
 
@@ -134,7 +139,19 @@ InAppPurchaseManager.prototype.updatedTransactionCallback = function(state, erro
 			}
 			return;
 	}
-}
+};
+
+InAppPurchaseManager.prototype.restoreCompletedTransactionsFinished = function() {
+  if (this.onRestoreCompletedTransactionsFinished) {
+    this.onRestoreCompletedTransactionsFinished();
+  }
+};
+
+InAppPurchaseManager.prototype.restoreCompletedTransactionsFailed = function(errorCode) {
+  if (this.onRestoreCompletedTransactionsFailed) {
+    this.onRestoreCompletedTransactionsFailed(errorCode);
+  }
+};
 
 /*
  * This queue stuff is here because we may be sent events before listeners have been registered. This is because if we have 

--- a/iPhone/InAppPurchaseManager/InAppPurchaseManager.m
+++ b/iPhone/InAppPurchaseManager/InAppPurchaseManager.m
@@ -133,6 +133,17 @@
     }
 }
 
+- (void)paymentQueue:(SKPaymentQueue *)queue restoreCompletedTranactionsFailedWithError:(NSError *)error
+{
+	NSString *js = [NSString stringWithFormat:@"plugins.inAppPurchaseManager.onRestoreCompletedTransactionsFailed(%d)", error.code];
+	[self writeJavascript: js];
+}
+
+- (void)paymentQueueRestoreCompletedTransactionsFinished:(SKPaymentQueue *)queue
+{
+	NSString *js = @"plugins.inAppPurchaseManager.onRestoreCompletedTransactionsFinished()";
+	[self writeJavascript: js];
+}
 
 @end
 


### PR DESCRIPTION
Add callback handlers for restoreCompletedTransactions of ios in app purchase.

After restoring completed transactions, the payment queue observer is
notified by a call to either
paymentQueue:restoreCompletedTransactionsFailedWithError: or
paymentQueueRestoreCompletedTransactionsFinished:.  This patch
delegates calls to these methods to callback functions on the
plugins.inAppPurchaseManager.
