### PR TITLE
fix typo in paymentQueue:restoreCompletedTransactionsFailedWithError:

### DIFF
--- a/iPhone/InAppPurchaseManager/InAppPurchaseManager.h
+++ b/iPhone/InAppPurchaseManager/InAppPurchaseManager.h
@@ -31,7 +31,7 @@
 - (void) requestProductData:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
 - (void) requestProductsData:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
 - (void) paymentQueue:(SKPaymentQueue *)queue updatedTransactions:(NSArray *)transactions;
-- (void) paymentQueue:(SKPaymentQueue *)queue restoreCompletedTranactionsFailedWithError:(NSError *)error;
+- (void) paymentQueue:(SKPaymentQueue *)queue restoreCompletedTransactionsFailedWithError:(NSError *)error;
 - (void) paymentQueueRestoreCompletedTransactionsFinished:(SKPaymentQueue *)queue;
 
 @end

--- a/iPhone/InAppPurchaseManager/InAppPurchaseManager.m
+++ b/iPhone/InAppPurchaseManager/InAppPurchaseManager.m
@@ -133,7 +133,7 @@
     }
 }
 
-- (void)paymentQueue:(SKPaymentQueue *)queue restoreCompletedTranactionsFailedWithError:(NSError *)error
+- (void)paymentQueue:(SKPaymentQueue *)queue restoreCompletedTransactionsFailedWithError:(NSError *)error
 {
 	NSString *js = [NSString stringWithFormat:@"plugins.inAppPurchaseManager.onRestoreCompletedTransactionsFailed(%d)", error.code];
 	[self writeJavascript: js];


### PR DESCRIPTION
Before, it said "Tranaction", which caused the fail callback not to be invoked. Sorry for that.
