### PR TITLE
Removing intent filter of MAIN so two BarcodeScanner icons don't show up

### DIFF
--- a/Android/BarcodeScanner/README.md
+++ b/Android/BarcodeScanner/README.md
@@ -28,10 +28,6 @@ Updates by Simon MacDonald
               android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
               android:windowSoftInputMode="stateAlwaysHidden">
       <intent-filter>
-        <action android:name="android.intent.action.MAIN"/>
-        <category android:name="android.intent.category.LAUNCHER"/>
-      </intent-filter>
-      <intent-filter>
         <action android:name="com.phonegap.plugins.barcodescanner.SCAN"/>
         <category android:name="android.intent.category.DEFAULT"/>
       </intent-filter>


### PR DESCRIPTION
This will fix Issue #205: Barcode Scanner / Android: Two "apps" loaded: my app and xzing app
