### PR TITLE
Fix iOS's inAppPurchaseManager's callback serialization errors.

### DIFF
--- a/iPhone/InAppPurchaseManager/InAppPurchaseManager.m
+++ b/iPhone/InAppPurchaseManager/InAppPurchaseManager.m
@@ -7,7 +7,7 @@
 //
 
 #import "InAppPurchaseManager.h"
-
+#import "JSONKit.h"
 
 @implementation InAppPurchaseManager
 
@@ -195,24 +195,19 @@
 @synthesize callback, command;
 
 - (void)productsRequest:(SKProductsRequest *)request didReceiveResponse:(SKProductsResponse *)response {
-	NSString *validProductsJS = @"";
-	NSString *invalidProductsJS = @"";
-	NSString *js = @"";
 
+    NSMutableArray *validProducts = [NSMutableArray array];
 	for (SKProduct *product in response.products) {
-		validProductsJS = [NSString
-							  stringWithFormat:
-								@"%@{id: '%@', title: '%@', description: '%@', price: '%@'}, ",
-							  validProductsJS,
-							  product.productIdentifier,
-							  product.localizedTitle,
-							  product.localizedDescription,
-							  product.localizedPrice];
+        [validProducts addObject:
+         [NSDictionary dictionaryWithObjectsAndKeys:
+          product.productIdentifier, @"id",
+          product.localizedTitle, @"title",
+          product.localizedDescription, @"description",
+          product.localizedPrice, @"price",
+          nil]];
     }
 
-	invalidProductsJS = [response.invalidProductIdentifiers componentsJoinedByString:@", "];
-
-	js = [NSString stringWithFormat:@"%@([%@], [%@]);", callback, validProductsJS, invalidProductsJS];
+	NSString *js = [NSString stringWithFormat:@"%@(%@, %@);", callback, [validProducts JSONString], [response.invalidProductIdentifiers JSONString]];
 	[command writeJavascript: js];
 
 	[request release];


### PR DESCRIPTION
For iOS's inAppPurchaseManager, fix serialization errors in requestProductsData's callback.

Calls to requestProductsData currently fails for the following two conditions:
1. Title or description contains single quotes
2. Invalid product IDs are returned.

Here's an example JavaScript statement generated:

```
window.plugins.inAppPurchaseManager.callbackMap.b0([{
    id: 'com.acme.product.1',
    title: 'Acme's #1 Product',
    description: 'Acme's #1 Product Description.',
    price: '$4.99'
}, ], [com.acme.product.5, com.acme.product.2, com.acme.product.4, com.acme.product.3]);
```

Note the single quotes in the product title and description (they are not escaped). Also, look at the invalid product IDs returned -- they are not quoted.
