### PR TITLE
Android ClipboardManager upgraded to phonegap 1.x

### DIFF
--- a/Android/ClipboardManager/ClipboardManagerPlugin.java
+++ b/Android/ClipboardManager/ClipboardManagerPlugin.java
@@ -1,6 +1,7 @@
 /**
  * Phonegap ClipboardManager plugin
  * Omer Saatcioglu 2011
+ * enhanced by Guillaume Charhon - Smart Mobile Software 2011
  *
  */
 
@@ -12,7 +13,6 @@ import org.json.JSONException;
 import android.content.Context;
 import android.text.ClipboardManager;
 
-import com.phonegap.DroidGap;
 import com.phonegap.api.Plugin;
 import com.phonegap.api.PluginResult;
 
@@ -24,11 +24,6 @@ public class ClipboardManagerPlugin extends Plugin {
 
 	private ClipboardManager mClipboardManager;
 
-	public void setContext(DroidGap ctx) {
-		super.setContext(ctx);
-		mClipboardManager = (ClipboardManager) ctx
-				.getSystemService(Context.CLIPBOARD_SERVICE);
-	}
 
 	/**
 	 * Executes the request and returns PluginResult.
@@ -42,6 +37,12 @@ public class ClipboardManagerPlugin extends Plugin {
 	 * @return A PluginResult object with a status and message.
 	 */
 	public PluginResult execute(String action, JSONArray args, String callbackId) {
+		// If we do not have the clipboard
+		if(mClipboardManager == null)
+			// get it
+			mClipboardManager = (ClipboardManager)ctx.getSystemService(Context.CLIPBOARD_SERVICE);
+		
+		// Copy
 		if (action.equals(actionCopy)) {
 			String arg = "";
 			try {
@@ -53,6 +54,8 @@ public class ClipboardManagerPlugin extends Plugin {
 				return new PluginResult(PluginResult.Status.ERROR, errorUnknown);
 			}
 			return new PluginResult(PluginResult.Status.OK, arg);
+			
+		// Paste
 		} else if (action.equals(actionPaste)) {
 			String arg = (String) mClipboardManager.getText();
 			if (arg == null) {

--- a/Android/ClipboardManager/README.md
+++ b/Android/ClipboardManager/README.md
@@ -1,13 +1,13 @@
 # ClipboardManager plugin for Phonegap #
 By Omer Saatcioglu
+Enhanced by Guillaume Charhon
 
 ## Adding the Plugin to your project ##
 1. To install the plugin, move clipboardmanager.js to your project's www folder and include a reference to it in your html files. 
 2. Create a folder called 'src/com/saatcioglu/phonegap/clipboardmanager' within your project's src folder.
-3. And copy ClipboardManagerPlugin.java into that new folder.
-
-`mkdir <your_project>/src/com/saatcioglu/phonegap/clipboardmanager`
-`cp ./ClipboardManagerPlugin.java <your_project>/src/com/beetight/barcodescanner`
+3. Copy ClipboardManagerPlugin.java into that new folder.
+4. Add in your plugins.xml (located in /res/xml/)
+<plugin name="ClipboardManager" value="com.saatcioglu.phonegap.clipboardmanager.ClipboardManagerPlugin"/>
 
 ## Using the plugin ##
 The plugin creates the object `window.plugins.clipboardManager` with the methods 
@@ -32,10 +32,6 @@ An example for paste:
 		function(e){alert(e)}
 	);
 
-	
-## BUGS AND CONTRIBUTIONS ##
-The latest version is available [at GitHub](https://github.com/osaatcioglu/phonegap-plugins/tree/master/Android)
-If you have a patch, fork my repo baby and send me a pull request. Submit bug reports on GitHub, please.
 	
 ## Licence ##
 The MIT License

--- a/Android/ClipboardManager/clipboardmanager.js
+++ b/Android/ClipboardManager/clipboardmanager.js
@@ -1,21 +1,21 @@
 /**
  * Phonegap ClipboardManager plugin
  * Omer Saatcioglu 2011
- *
+ * Guillaume Charhon - Smart Mobile Software 2011
  */
 
 var ClipboardManager = function() { 
 }
 
+
 ClipboardManager.prototype.copy = function(str, success, fail) {
-	PhoneGap.execAsync(success, fail, "ClipboardManager", "copy", [str,]);
+	PhoneGap.exec(success, fail, "ClipboardManager", "copy", [str]);
 };
 
 ClipboardManager.prototype.paste = function(success, fail) {
-	PhoneGap.execAsync(success, fail, "ClipboardManager", "paste", []);
+	PhoneGap.exec(success, fail, "ClipboardManager", "paste", []);
 };
 
 PhoneGap.addConstructor(function() {
 	PhoneGap.addPlugin('clipboardManager', new ClipboardManager());
-	PluginManager.addService("ClipboardManager","com.saatcioglu.phonegap.clipboardmanager.ClipboardManagerPlugin");
 });


### PR DESCRIPTION
Hello,

the plugin was not working with phonegap 1.x. 
https://groups.google.com/forum/#!topic/phonegap/jsZTEEmoYDI
There was also an error in the java code which I also corrected.
I corrected also the instructions to take into account the plugin.xml file.
