### PR TITLE
Fixed: empty space inside "bad   ge";

### DIFF
--- a/iPhone/NativeControls/NativeControls.m
+++ b/iPhone/NativeControls/NativeControls.m
@@ -251,7 +251,7 @@
     NSString  *name = [arguments objectAtIndex:0];
     UITabBarItem *item = [tabBarItems objectForKey:name];
     if (item)
-        item.badgeValue = [options objectForKey:@"bad   ge"];
+        item.badgeValue = [options objectForKey:@"badge"];
 }
 
 


### PR DESCRIPTION
Fixed: empty space inside "bad   ge"; Otherwise method: updateTabBarItem with options (badge: "x") wont work. -Frank
