### PR TITLE
fix for #231 - remove JSON headers iOS BarcodeScanner

### DIFF
--- a/iPhone/BarcodeScanner/PGBarcodeScanner.mm
+++ b/iPhone/BarcodeScanner/PGBarcodeScanner.mm
@@ -18,10 +18,8 @@
 
 #ifdef PHONEGAP_FRAMEWORK
 #import <PhoneGap/PGPlugin.h>
-#import <PhoneGap/JSON.h>
 #else
 #import "PGPlugin.h"
-#import "JSON.h"
 #endif
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
The BarcodeScanner was needlessly include JSON headers.  Even though they weren't used, this broke folks moving from < 1.2.0 to > 1.2.0, since we switched JSON packages at the time, and the header names changed.
