### PR TITLE
Volume slider updated for PhoneGap 1.2.0

### DIFF
--- a/iPhone/VolumeSlider/README.md
+++ b/iPhone/VolumeSlider/README.md
@@ -12,7 +12,7 @@ Add the plugin much like any other:
 2.      Add the VolumeSlider.js file to your www folder
 3.	Add the VolumeSlider.js to your html file. eg: `<script type="text/javascript" charset="utf-8" src="VolumeSlider.js"></script>`
 4.      Add the plugin to the PhoneGap.plist
-5.      Here is where it differs slightly, [add the MediaPlayer.framework to your project in Xcode](http://paikialog.wordpress.com/2011/03/09/xcode-4how-to-add-framework-into-project/ "Xcode 4–How to add Framework into project?") (this is where MPVolumeView comes from).
+5.      Here is where it differs slightly, if not already added by PhoneGap, [add the MediaPlayer.framework to your project in Xcode](http://paikialog.wordpress.com/2011/03/09/xcode-4how-to-add-framework-into-project/ "Xcode 4–How to add Framework into project?") (this is where MPVolumeView comes from).
 
 ### Example
 ```javascript

--- a/iPhone/VolumeSlider/VolumeSlider.h
+++ b/iPhone/VolumeSlider/VolumeSlider.h
@@ -16,15 +16,17 @@
 
 
 @interface VolumeSlider : PGPlugin <UITabBarDelegate> {
+	NSString* callbackId;
 	UIView* mpVolumeViewParentView;
 	MPVolumeView* myVolumeView;
 }
 
+@property (nonatomic, copy) NSString* callbackId;
 @property (nonatomic, retain) UIView* mpVolumeViewParentView;
 @property (nonatomic, retain) MPVolumeView* myVolumeView;
 
-- (void)createVolumeSlider:(NSArray*)arguments withDict:(NSDictionary*)options;
-- (void)showVolumeSlider:(NSArray*)arguments withDict:(NSDictionary*)options;
-- (void)hideVolumeSlider:(NSArray*)arguments withDict:(NSDictionary*)options;
+- (void)createVolumeSlider:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+- (void)showVolumeSlider:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+- (void)hideVolumeSlider:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
 
 @end

--- a/iPhone/VolumeSlider/VolumeSlider.js
+++ b/iPhone/VolumeSlider/VolumeSlider.js
@@ -3,7 +3,7 @@
 //  	Volume Slider PhoneGap Plugin
 //
 //  	Created by Tommy-Carlos Williams on 20/07/25.
-//  	Copyright 2011 Devgeeks. All rights reserved.
+//  	Copyright 2011 Tommy-Carlos Williams. All rights reserved.
 //      MIT Licensed
 //
 

--- a/iPhone/VolumeSlider/VolumeSlider.js
+++ b/iPhone/VolumeSlider/VolumeSlider.js
@@ -15,20 +15,20 @@ var VolumeSlider = function(){
  * Create a volume slider.
  */
 VolumeSlider.prototype.createVolumeSlider = function(originx,originy,width,height) {
-    PhoneGap.exec("VolumeSlider.createVolumeSlider", originx, originy, width, height);
+    PhoneGap.exec(null, null, "VolumeSlider","createVolumeSlider", [originx, originy, width, height]);
 };
 
 /**
  * Show the volume slider
  */
 VolumeSlider.prototype.showVolumeSlider = function() {
-    PhoneGap.exec("VolumeSlider.showVolumeSlider");
+    PhoneGap.exec(null, null, "VolumeSlider","showVolumeSlider", []);
 };
 /**
  * Hide the volume slider
  */
 VolumeSlider.prototype.hideVolumeSlider = function() {
-    PhoneGap.exec("VolumeSlider.hideVolumeSlider");
+    PhoneGap.exec(null, null, "VolumeSlider","hideVolumeSlider", []);
 };
 
 

--- a/iPhone/VolumeSlider/VolumeSlider.m
+++ b/iPhone/VolumeSlider/VolumeSlider.m
@@ -12,7 +12,7 @@
 
 @implementation VolumeSlider
 
-@synthesize mpVolumeViewParentView, myVolumeView;
+@synthesize mpVolumeViewParentView, myVolumeView, callbackId;
 
 #ifndef __IPHONE_3_0
 @synthesize webView;
@@ -35,8 +35,9 @@
 #pragma mark -
 #pragma mark VolumeSlider
 
-- (void) createVolumeSlider:(NSArray*)arguments withDict:(NSDictionary*)options
+- (void) createVolumeSlider:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options
 {	
+	self.callbackId = arguments.pop;
 	NSUInteger argc = [arguments count];
 	
 	if (argc < 3) { // at a minimum we need x origin, y origin and width...
@@ -69,13 +70,13 @@
 	self.myVolumeView.showsVolumeSlider = NO;
 }
 
-- (void)showVolumeSlider:(NSArray*)arguments withDict:(NSDictionary*)options
+- (void)showVolumeSlider:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options
 {
 	self.myVolumeView.showsVolumeSlider = YES;
 	self.mpVolumeViewParentView.hidden = NO;
 }
 
-- (void)hideVolumeSlider:(NSArray*)arguments withDict:(NSDictionary*)options
+- (void)hideVolumeSlider:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options
 {
 	self.mpVolumeViewParentView.hidden = YES;
 	self.myVolumeView.showsVolumeSlider = NO;


### PR DESCRIPTION
I have updated the plugin to use the proper PhoneGap.exec signature for 1.0+ 

I have also updated the README to mention the possibility that PhoneGap has already included the framework needed for the MPVolumeView
