### PR TITLE
Update to allow the iPhone barcode scanner plugin to use a custom xib file for the overlay view.

### DIFF
--- a/iPhone/BarcodeScanner/PGBarcodeScanner.mm
+++ b/iPhone/BarcodeScanner/PGBarcodeScanner.mm
@@ -221,6 +221,7 @@
         self.viewController = nil;
         self.captureSession = nil;
         self.previewLayer = nil;
+        self.alternateXib = nil;
 
         self.capturing = NO;
 
@@ -606,6 +607,7 @@
         self.view = nil;
         self.processor = nil;
         self.shutterPressed = NO;
+        self.alternateXib = nil;
 
         [super dealloc];
     }

--- a/iPhone/BarcodeScanner/barcodescanner.js
+++ b/iPhone/BarcodeScanner/barcodescanner.js
@@ -44,8 +44,11 @@ BarcodeScanner.prototype.scan = function(success, fail, options) {
         fail("success callback parameter must be a function")
         return
     }
+  
+    if ( null == options ) 
+      options = []
 
-    return PhoneGap.exec(successWrapper, fail, "com.phonegap.barcodeScanner", "scan", [])
+    return PhoneGap.exec(successWrapper, fail, "com.phonegap.barcodeScanner", "scan", options)
 }
 
 //-------------------------------------------------------------------


### PR DESCRIPTION
Updated to allow the user to define a xib file for the interface.  The name of the xib file can then be passed into the scan method.  In the example below, the actual xib file is called BarcodeOverlay.xib.  Also updated the cancel method to be linkable from within the xib.

```
function scan() {
    window.plugins.barcodeScanner.scan(
    function(result) {
        if (result.cancelled)
        alert("the user cancelled the scan")
        else
        alert("we got a barcode: " + result.text)
    },
    function(error) {
        alert("scanning failed: " + error)
    },
    ["BarcodeOverlay"]
    )
}
```
