### PR TITLE
Created another clean&simple plugin `iPhone/ActionSheet`

### DIFF
--- a/iPhone/ActionSheet/ActionSheet.h
+++ b/iPhone/ActionSheet/ActionSheet.h
@@ -1,0 +1,23 @@
+//
+//  ActionSheet.h
+//  
+// Created by Olivier Louvignes on 11/27/2011.
+//
+// Copyright 2011 Olivier Louvignes. All rights reserved.
+// MIT Licensed
+
+#import <Foundation/Foundation.h>
+#import <PhoneGap/PGPlugin.h>
+
+@interface ActionSheet : PGPlugin <UIActionSheetDelegate> {
+    
+	NSString* callbackID;
+
+}
+
+@property (nonatomic, copy) NSString* callbackID;
+
+//Instance Method  
+- (void) create:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+
+@end

--- a/iPhone/ActionSheet/ActionSheet.js
+++ b/iPhone/ActionSheet/ActionSheet.js
@@ -1,0 +1,44 @@
+//
+//  ActionSheet.js
+//
+// Created by Olivier Louvignes on 11/27/2011.
+//
+// Copyright 2011 Olivier Louvignes. All rights reserved.
+// MIT Licensed
+
+function ActionSheet() {}
+
+ActionSheet.prototype.create = function(title, items, fn, options) {
+	if(!options) options = {};
+
+	var service = 'ActionSheet',
+		callbackId = service + (PhoneGap.callbackId + 1);
+
+	var config = {
+		title : title+'' || 'Title',
+		items : items || ['Cancel'],
+		callback : fn || function(){},
+		scope: options.hasOwnProperty('scope') ? options.scope : null,
+		style : options.hasOwnProperty('style') ? options.style+'' : 'default',
+		destructiveButtonIndex : options.hasOwnProperty('destructiveButtonIndex') ? options.destructiveButtonIndex*1 : false,
+		cancelButtonIndex : options.hasOwnProperty('cancelButtonIndex') ? options.cancelButtonIndex*1 : false
+	};
+
+	var callback = function(result) {
+		var buttonValue = false, // value for cancelButton
+			buttonIndex = result.buttonIndex;
+
+		if(!config.cancelButtonIndex || result.buttonIndex != config.cancelButtonIndex) {
+			buttonValue = config.items[result.buttonIndex];
+		}
+
+		config.callback.call(config.scope || null, button, result.buttonIndex);
+	};
+
+	PhoneGap.exec(callback, callback, 'ActionSheet', 'create', [config]);
+};
+
+PhoneGap.addConstructor(function() {
+	if(!window.plugins) window.plugins = {};
+	window.plugins.actionSheet = new ActionSheet();
+});

--- a/iPhone/ActionSheet/ActionSheet.m
+++ b/iPhone/ActionSheet/ActionSheet.m
@@ -1,0 +1,98 @@
+//
+//  ActionSheet.m
+//  
+// Created by Olivier Louvignes on 11/27/2011.
+//
+// Copyright 2011 Olivier Louvignes. All rights reserved.
+// MIT Licensed
+
+#import "ActionSheet.h" 
+
+@implementation ActionSheet 
+
+@synthesize callbackID;
+
+-(void)create:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options  
+{
+	
+	//NSLog(@"options: %@", options);
+	//NSLog(@"arguments: %@", arguments);
+	
+	// The first argument in the arguments parameter is the callbackID.
+	// We use this to send data back to the successCallback or failureCallback
+	// through PluginResult.
+	self.callbackID = [arguments pop];
+	
+	// Compiling options with defaults
+	NSString *title = [options objectForKey:@"title"] ?: @"";
+	NSString *style = [options objectForKey:@"style"] ?: @"black-translucent";
+	NSArray *items = [options objectForKey:@"items"];
+	NSInteger cancelButtonIndex = [[options objectForKey:@"cancelButtonIndex"] intValue] ?: false;
+	NSInteger destructiveButtonIndex = [[options objectForKey:@"destructiveButtonIndex"] intValue] ?: false;
+	
+	// Create actionSheet
+	UIActionSheet *actionSheet = [[UIActionSheet alloc] initWithTitle:title
+												   delegate:self
+										  cancelButtonTitle:nil
+									 destructiveButtonTitle:nil
+										  otherButtonTitles:nil];
+	
+	// Style actionSheet, defaults to BlackTranslucent
+	if([style isEqualToString:@"black-opaque"]) actionSheet.actionSheetStyle = UIActionSheetStyleBlackOpaque;
+	else actionSheet.actionSheetStyle = UIActionSheetStyleBlackTranslucent;
+	
+	// Fill with elements
+	for(int i = 0; i < [items count]; i++) {
+		[actionSheet addButtonWithTitle:[items objectAtIndex:i]];
+	}
+	// Handle cancelButtonIndex
+	if([options objectForKey:@"cancelButtonIndex"]) {
+		actionSheet.cancelButtonIndex = cancelButtonIndex;
+	}
+	// Handle destructiveButtonIndex
+	if([options objectForKey:@"destructiveButtonIndex"]) {
+		actionSheet.destructiveButtonIndex = destructiveButtonIndex;
+	}
+
+	// Toggle ActionSheet
+    [actionSheet showInView:self.webView.superview];
+
+}
+
+/*-(void)show:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options  
+{
+	// Toggle ActionSheet
+    [self.actionSheet showInView:self.webView.superview];
+}*/
+
+// ActionSheet generic dismiss
+- (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex
+{
+	//NSLog(@"didDismissWithButtonIndex:%d", buttonIndex);
+	
+	// Build returned result
+	NSMutableDictionary *result = [[NSMutableDictionary alloc] init];
+	[result setObject:[NSNumber numberWithInteger:buttonIndex] forKey:@"buttonIndex"];
+	
+	// Create Plugin Result
+	PluginResult* pluginResult = [PluginResult resultWithStatus:PGCommandStatus_OK messageAsDictionary:result];
+	
+	// Checking if cancel was clicked
+	if (buttonIndex != actionSheet.cancelButtonIndex) {
+		//Call  the Failure Javascript function
+		[self writeJavascript: [pluginResult toErrorCallbackString:self.callbackID]];
+	// Checking if destructive was clicked
+	} else if (buttonIndex != actionSheet.destructiveButtonIndex) {
+		//Call  the Success Javascript function
+		[self writeJavascript: [pluginResult toSuccessCallbackString:self.callbackID]];
+	// Other button was clicked
+	} else {    
+		//Call  the Success Javascript function
+		[self writeJavascript: [pluginResult toSuccessCallbackString:self.callbackID]];
+	}
+	
+	// Release objects
+	[actionSheet release];
+}
+
+@end

--- a/iPhone/ActionSheet/README.md
+++ b/iPhone/ActionSheet/README.md
@@ -1,13 +1,13 @@
-# PhoneGap MessageBox Plugin #
+# PhoneGap ActionSheet Plugin #
 by `Olivier Louvignes`
 
 ## DESCRIPTION ##
 
-* This plugin provides an unified API to use the `UIAlertView` native component from IOS. It does comply with the latest (future-2.x) phonegap standards.
+* This plugin provides a simple way to use the `UIActionSheet` native component from IOS. It does comply with the latest (future-2.x) phonegap standards.
 
-* Compared to the `iPhone/Prompt` plugin, it is more documented & simpler to understand. It does also provide new options for prompt (message, multiline, input type password).
+* Compared to the `iPhone/NativeControls` plugin, it is more documented & simpler to understand (only handle actionSheets). It does also provide new options (style).
 
-* There is a `Sencha Touch 2.0` plugin to easily leverage this plugin [here](https://github.com/mgcrea/phonegap-plugins/wiki/iPhone-MessageBox)
+* There is a `Sencha Touch 2.0` plugin to easily leverage this plugin [here](https://github.com/mgcrea/phonegap-plugins/wiki/iPhone-ActionSheet)
 
 ## SETUP ##
 
@@ -16,26 +16,20 @@ Using this plugin requires [iPhone PhoneGap](http://github.com/phonegap/phonegap
 1. Make sure your PhoneGap Xcode project has been [updated for the iOS 4 SDK](http://wiki.phonegap.com/Upgrade-your-PhoneGap-Xcode-Template-for-iOS-4)
 2. Drag and drop the `MessageBox` folder from Finder to your Plugins folder in XCode, using "Create groups for any added folders"
 3. Add the .js files to your `www` folder on disk, and add reference(s) to the .js files as <link> tags in your html file(s)
-4. Add new entry with key `MessageBox` and value `MessageBox` to `Plugins` in `PhoneGap.plist`
+4. Add new entry with key `ActionSheet` and value `ActionSheet` to `Plugins` in `PhoneGap.plist`
 
 ## JAVASCRIPT INTERFACE ##
 
     // After device ready, create a local alias
-    var messageBox = window.plugins.messageBox;
+    var actionSheet = window.plugins.actionSheet;
 
-    // Alert
-    messageBox.alert('Title', 'Message', function(button) { console.warn('alert', [this, arguments]); });
+    // Basic with title
+    actionSheet.create('Title', ['Foo', 'Bar'], function(buttonValue, buttonIndex) { console.warn('create', [this, arguments]); });
 
-    // Confirm
-    messageBox.confirm('Title', 'Message', function(button) { console.warn('confirm', [this, arguments]); });
+    // Complex
+    actionSheet.create(null, ['Add', 'Delete', 'Cancel'], function(buttonValue, buttonIndex) { console.warn('create', [this, arguments]); }, {destructiveButtonIndex: 1, cancelButtonIndex: 2});
 
-    // Default prompt
-    messageBox.prompt('Title', 'Message', function(button, value) { console.warn('prompt', [this, arguments]); });
-
-    // Prompt a password
-    messageBox.prompt('Please enter your password', '', function(button, value) { console.warn('prompt', [this, arguments]); }, {placeholder: 'password', type: 'password'});
-
-* Check [source](http://github.com/mgcrea/phonegap-plugins/tree/master/iPhone/MessageBox/MessageBox.js) for additional configuration.
+* Check [source](http://github.com/mgcrea/phonegap-plugins/tree/master/iPhone/ActionSheet/ActionSheet.js) for additional configuration.
 
 ## BUGS AND CONTRIBUTIONS ##
 
@@ -43,7 +37,7 @@ Patches welcome! Send a pull request. Since this is not a part of PhoneGap Core 
 
 Post issues on [Github](http://github.com/phonegap/phonegap-plugins/issues)
 
-The latest code (my fork) will always be [here](http://github.com/mgcrea/phonegap-plugins/tree/master/iPhone/MessageBox/)
+The latest code (my fork) will always be [here](http://github.com/mgcrea/phonegap-plugins/tree/master/iPhone/ActionSheet/)
 
 ## LICENSE ##
 
@@ -61,6 +55,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 Inspired by :
 
-* [Prompt Phonegap plugin](https://github.com/phonegap/phonegap-plugins/tree/master/iPhone/Prompt)
+* [NativeControls Phonegap plugin](https://github.com/phonegap/phonegap-plugins/tree/master/iPhone/NativeControls)
 
-* [MessageBox Sencha Touch 2.0 class](http://docs.sencha.com/touch/2-0/#!/api/Ext.MessageBox)
+* [ActionSheet Sencha Touch 2.0 class](http://docs.sencha.com/touch/2-0/#!/api/Ext.ActionSheet)


### PR DESCRIPTION
I think ActionSheet should stand in a simple standalone plugin, so I built it.
Had a hard time to make NativeControls work because of the lack of docs.
Also it provides (one) more option(s) & is well documented.

Finally it does comply with phonegap 2.x future specs (about plugins callbacks).
