### PR TITLE
Fix for broken plugin callback in PrintPlugin iOS plugin in phonegap 1.2.0

### DIFF
--- a/iPhone/PrintPlugin/PrintPlugin.js
+++ b/iPhone/PrintPlugin/PrintPlugin.js
@@ -4,29 +4,32 @@
  * MIT licensed
  */
 
-var PrintPlugin = function() { 
-    
+var PrintPlugin = function() {
+
 }
+
+PrintPlugin.prototype.callbackMap = {};
+PrintPlugin.prototype.callbackIdx = 0;
 
 /*
  print      - html string or DOM node (if latter, innerHTML is used to get the contents). REQUIRED.
  success    - callback function called if print successful.     {success: true}
  fail       - callback function called if print unsuccessful.  If print fails, {error: reason}. If printing not available: {available: false}
- options    -  {dialogOffset:{left: 0, right: 0}}. Position of popup dialog (iPad only). 
+ options    -  {dialogOffset:{left: 0, right: 0}}. Position of popup dialog (iPad only).
  */
 PrintPlugin.prototype.print = function(printHTML, success, fail, options) {
     if (typeof printHTML != 'string'){
         console.log("Print function requires an HTML string. Not an object");
         return;
     }
-    
-    
+
+
     //var printHTML = "";
-    
+
     var dialogLeftPos = 0;
     var dialogTopPos = 0;
-   
-    
+
+
     if (options){
         if (options.dialogOffset){
             if (options.dialogOffset.left){
@@ -43,16 +46,35 @@ PrintPlugin.prototype.print = function(printHTML, success, fail, options) {
             }
         }
     }
-    
-    
-    return PhoneGap.exec("PrintPlugin.print", printHTML, GetFunctionName(success), GetFunctionName(fail), dialogLeftPos, dialogTopPos);
+
+    var key = 'print' + this.callbackIdx++;
+    window.plugins.printPlugin.callbackMap[key] = {
+        success: function(result) {
+            delete window.plugins.printPlugin.callbackMap[key];
+            success(result);
+        },
+        fail: function(result) {
+            delete window.plugins.printPlugin.callbackMap[key];
+            fail(result);
+        },
+    };
+
+    var callbackPrefix = 'window.plugins.printPlugin.callbackMap.' + key;
+    return PhoneGap.exec("PrintPlugin.print", printHTML, callbackPrefix + '.success', callbackPrefix + '.fail', dialogLeftPos, dialogTopPos);
 };
 
 /*
  * Callback function returns {available: true/false}
  */
-PrintPlugin.prototype.isPrintingAvailable = function(result) {
-    return PhoneGap.exec("PrintPlugin.isPrintingAvailable", GetFunctionName(result));
+PrintPlugin.prototype.isPrintingAvailable = function(callback) {
+    var key = 'isPrintingAvailable' + this.callbackIdx++;
+    window.plugins.printPlugin.callbackMap[key] = function(result) {
+        delete window.plugins.printPlugin.callbackMap[key];
+        callback(result);
+    };
+
+    var callbackName = 'window.plugins.printPlugin.callbackMap.' + key;
+    PhoneGap.exec("PrintPlugin.isPrintingAvailable", callbackName);
 };
 
 PhoneGap.addConstructor(function() {


### PR DESCRIPTION
Since GetFunctionName was removed in https://github.com/shazron/phonegap-iphone/commit/5544b2a0664ae2714ec1df2b6e16aa97d3cfa9bc the PrintPlugin stopped working. I've taken a note from the BarcodePlugin plugin and created a plugin map with proper disposal of callback methods.
