### PR TITLE
Fix issues in BarcodeScanner README.md.

### DIFF
--- a/BlackBerry/BarcodeScanner/README.md
+++ b/BlackBerry/BarcodeScanner/README.md
@@ -26,20 +26,23 @@ Using this plugin requires [BlackBerry-WebWorks PhoneGap](http://github.com/phon
 
 1. Copy barcodescanner.js to your project and include a reference to it in your html file after phonegap.js.
 
-    <script type="text/javascript" charset="utf-8" src="phonegap.js"></script>
-    <script type="text/javascript" charset="utf-8" src="barcodescanner.js"></script>
+    &lt;script type="text/javascript" charset="utf-8" src="phonegap.js"&gt;&lt;/script&gt;
 
-2. Add the common plugin source to your phonegap.jar in your projects ext folder.  The phonegap.jar file is a jar of source code.  Open phonegap.jar with your favorite archive manager or use the jar command to create a directory called "src/com/phonegap/plugins/barcodescanner" and copy `BarcodeScanner.java`, `EncodeAction.java`, `ScanAction.java` into it.
+    &lt;script type="text/javascript" charset="utf-8" src="barcodescanner.js"&gt;&lt;/script&gt;
+
+2. Add the common plugin source to your phonegap.jar in your projects ext folder.  The phonegap.jar file is a jar of source code.  Open phonegap.jar with your favorite archive manager or use the jar command to create a directory called "src/com/phonegap/plugins/barcodescanner" inside the jar and copy `BarcodeScanner.java`, `EncodeAction.java`, `ScanAction.java` into it.
 
 3. Add the OS specific code to the phonegap.jar file.
 
-    *For an OS 5 based build:* Copy `AdvancedMultimediaManager.java`, `Encoder.java`, `LuminanceSourceBitmap.java`, and `Scanner.java` from the OS5 directory to "src/com/phonegap/plugins/barcodescanner" in phonegap.jar.  Copy the prebuilt ZXing jar `zxingcore.jar` from the OS5 directory to the root of phonegap.jar.
+    *For an OS 5 based build:* Copy `AdvancedMultimediaManager.java`, `Encoder.java`, `LuminanceSourceBitmap.java`, and `Scanner.java` from the OS5 directory to "src/com/phonegap/plugins/barcodescanner" in phonegap.jar.  Copy the prebuilt ZXing jar `zxingcore.jar` from the OS5 directory to the root (same level in hierarchy as src folder) of phonegap.jar.
 
     *For an OS 6 based build:* Copy `Encoder.java` and `Scanner.java` from the OS6 directory to "src/com/phonegap/plugins/barcodescanner" in phonegap.jar.
 
-4. In your projects plugins.xml file add the following line:
+4. If you had to unjar phonegap.jar to add the plugin source, recreate the phonegap.jar by creating a jar archive which has the src folder (and zxingcore.jar for OS 5) at its root.  Make sure the resulting phonegap.jar is in your projects ext folder and is the only phonegap.jar in the folder.
 
-    <plugin name="BarcodeScanner" value="com.phonegap.plugins.barcodescanner.BarcodeScanner"/>
+5. In your projects plugins.xml file add the following line:
+
+    &lt;plugin name="BarcodeScanner" value="com.phonegap.plugins.barcodescanner.BarcodeScanner"/&gt;
 
 If you have chosen to use the OS 6 based implementation AND you are using a version of the BlackBerry WebWorks SDK prior to v2.2 then additional steps are required. You will need to change the library that the BlackBerry WebWorks tools build against.  Follow the steps below to setup your environment to build against OS 6.
 


### PR DESCRIPTION
- Escape '<' and '>' characters so XML is displayed properly.
- Add details to step #3 and add new step #4 in 'Adding the
  Plugin to your project'.
