### PR TITLE
Fix for Issue #225 (https://github.com/phonegap/phonegap-plugins/issues/225).

### DIFF
--- a/iPhone/BarcodeScanner/PGBarcodeScanner.mm
+++ b/iPhone/BarcodeScanner/PGBarcodeScanner.mm
@@ -286,7 +286,7 @@
     - (NSString*)setUpCaptureSession {
         NSError* error = nil;
 
-        AVCaptureSession* captureSession = [[[AVCaptureSession alloc] init] autorelease];
+        AVCaptureSession* captureSession = [[AVCaptureSession alloc] init];
         self.captureSession = captureSession;
 
         AVCaptureDevice* device = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];


### PR DESCRIPTION
 PGbcsProcessor.captureSession no longer initialized as autorelease since it's released manually in dealloc.  This prevents a double release crash scenario when an autorelease pool is drained before the controller is dealloc'd.
