### PR TITLE
iOS Fix for IAP: apply()'s "this" argument needs to be set.

### DIFF
--- a/iPhone/InAppPurchaseManager/InAppPurchaseManager.m
+++ b/iPhone/InAppPurchaseManager/InAppPurchaseManager.m
@@ -153,7 +153,7 @@
                                  NILABLE(productId),
                                  NILABLE(transactionReceipt),
                                  nil];
-		NSString *js = [NSString stringWithFormat:@"plugins.inAppPurchaseManager.updatedTransactionCallback.apply(null, %@)", [callbackArgs JSONSerialize]];
+		NSString *js = [NSString stringWithFormat:@"plugins.inAppPurchaseManager.updatedTransactionCallback.apply(plugins.inAppPurchaseManager, %@)", [callbackArgs JSONSerialize]];
 		NSLog(@"js: %@", js);
 		[self writeJavascript: js];
 		[[SKPaymentQueue defaultQueue] finishTransaction:transaction];
@@ -191,7 +191,7 @@
                                  NILABLE(product.localizedDescription),
                                  NILABLE(product.localizedPrice),
                                  nil];
-		NSString *js = [NSString stringWithFormat:@"%@.apply(null, %@)", successCallback, [callbackArgs JSONSerialize]];
+		NSString *js = [NSString stringWithFormat:@"%@.apply(plugins.inAppPurchaseManager, %@)", successCallback, [callbackArgs JSONSerialize]];
 		NSLog(@"js: %@", js);
 		[command writeJavascript: js];
     }
@@ -245,7 +245,7 @@
                              NILABLE(validProducts),
                              NILABLE(response.invalidProductIdentifiers),
                              nil];
-	NSString *js = [NSString stringWithFormat:@"%@.apply(null, %@);", callback, [callbackArgs JSONSerialize]];
+	NSString *js = [NSString stringWithFormat:@"%@.apply(plugins.inAppPurchaseManager, %@);", callback, [callbackArgs JSONSerialize]];
 	[command writeJavascript: js];
 
 	[request release];


### PR DESCRIPTION
In my previous pull request (which was already merged to master), I changed the JavaScript callbacks to use `apply()` and set the "this" argument to the apply() call to `null`. This caused code in `InAppPurchaseManager.prototype.updatedTransactionCallback` to fail because, inside that method, references to `this` become references to `null` instead of the default instance of `InAppPurchaseManager`.

This commit modifies the `apply()` calls to use `plugins.inAppPurchaseManager` as the "this" argument.
