### PR TITLE
Fix for issue #278 (https://github.com/phonegap/phonegap-plugins/issues/278)

### DIFF
--- a/Android/ChildBrowser/src/com/phonegap/plugins/childBrowser/ChildBrowser.java
+++ b/Android/ChildBrowser/src/com/phonegap/plugins/childBrowser/ChildBrowser.java
@@ -147,6 +147,7 @@ public class ChildBrowser extends Plugin {
      */
     private void closeDialog() {
         if (dialog != null) {
+            this.webview.stopLoading();
             dialog.dismiss();
         }
     }


### PR DESCRIPTION
Call stopLoading() when dismissing dialog
