### PR TITLE
[Android] #292 ChildBrowser.onLocationChange timing inconsistency between iPhone and Android

### DIFF
--- a/Android/ChildBrowser/src/com/phonegap/plugins/childBrowser/ChildBrowser.java
+++ b/Android/ChildBrowser/src/com/phonegap/plugins/childBrowser/ChildBrowser.java
@@ -390,7 +390,11 @@ public class ChildBrowser extends Plugin {
             if (!newloc.equals(edittext.getText().toString())) {           
                 edittext.setText(newloc);
             }
-            
+        }
+
+        @Override
+        public void onPageFinished(WebView view, String url) {
+            super.onPageFinished(view, url);
             try {
                 JSONObject obj = new JSONObject();
                 obj.put("type", LOCATION_CHANGED_EVENT);


### PR DESCRIPTION
This is a small patch for ChildBrowser for Android to fire onLocationChange event when loading the page is finished, in a compatible way as its iPhone version.
