### PR TITLE
AdPlugin: Orientation not being set correctly when device is flat

### DIFF
--- a/iPhone/AdPlugin/SAiOSAdPlugin.m
+++ b/iPhone/AdPlugin/SAiOSAdPlugin.m
@@ -102,14 +102,14 @@
 	}
     
     self.isLandscape = NO;
-    UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
+    UIInterfaceOrientation orientation = [[UIApplication sharedApplication] statusBarOrientation];
     switch (orientation) {
-        case UIDeviceOrientationPortrait:
-        case UIDeviceOrientationPortraitUpsideDown:
+        case UIInterfaceOrientationPortrait:
+        case UIInterfaceOrientationPortraitUpsideDown:
             self.isLandscape = NO;
             break;
-        case UIDeviceOrientationLandscapeLeft:
-        case UIDeviceOrientationLandscapeRight:
+        case UIInterfaceOrientationLandscapeLeft:
+        case UIInterfaceOrientationLandscapeRight:
             self.isLandscape = YES;
             break;
         default:


### PR DESCRIPTION
UIDevice measures orientation based on accelerometer - which does not work if the device is flat. Using the status bar orientation will work no matter what.

See http://stackoverflow.com/questions/930075/uidevice-orientation
