### PR TITLE
iOS > ChildBrowser > Display a message when navigation fails

### DIFF
--- a/iPhone/ChildBrowser/ChildBrowserViewController.m
+++ b/iPhone/ChildBrowser/ChildBrowserViewController.m
@@ -219,5 +219,21 @@
 
 }
 
+- (void)webView:(UIWebView *)wv didFailLoadWithError:(NSError *)error {
+    NSLog (@"webView:didFailLoadWithError");
+    [spinner stopAnimating];
+    addressLabel.text = @"Failed";
+    if (error != NULL) {
+        UIAlertView *errorAlert = [[UIAlertView alloc]
+                                   initWithTitle: [error localizedDescription]
+                                   message: [error localizedFailureReason]
+                                   delegate:nil
+                                   cancelButtonTitle:@"OK"
+                                   otherButtonTitles:nil];
+        [errorAlert show];
+        [errorAlert release];
+    }
+}
+
 
 @end


### PR DESCRIPTION
Current behaviour was that when anything went wrong during the request NOTHING happened. I spend a lot of time to find what I'm doing wrong, that the ChildBrowser is not working - until I realised that the URL is wrong. Spinner was spinning. Nothing in XCode log. Address bar text was "Loading ...". 

I changed the behaviour to: 
- alert is shown with error description
- address panel text changed
- spinner stopped
