### PR TITLE
iOS > ChildBrowser > Message no longer shown for interrupted page loading...

### DIFF
--- a/iPhone/ChildBrowser/ChildBrowserViewController.m
+++ b/iPhone/ChildBrowser/ChildBrowserViewController.m
@@ -224,6 +224,7 @@
     [spinner stopAnimating];
     addressLabel.text = @"Failed";
     if (error != NULL) {
+        if (error.code == NSURLErrorCancelled) return;
         UIAlertView *errorAlert = [[UIAlertView alloc]
                                    initWithTitle: [error localizedDescription]
                                    message: [error localizedFailureReason]


### PR DESCRIPTION
It uses constant for better readability (see https://github.com/phonegap/phonegap-plugins/pull/314#issuecomment-3518974)
