### PR TITLE
iOS > EmailComposer > FIX: Without email account there is an error, that...

### DIFF
--- a/iPhone/EmailComposer/EmailComposer.m
+++ b/iPhone/EmailComposer/EmailComposer.m
@@ -61,8 +61,9 @@
 	//  NSData *myData = [NSData dataWithContentsOfFile:path];
 	//  [picker addAttachmentData:myData mimeType:@"image/png" fileName:@"rainy"];
     
-    
-    [[ super appViewController ] presentModalViewController:picker animated:YES];
+    if (picker != nil) {
+        [[ super appViewController ] presentModalViewController:picker animated:YES];
+    }
     [picker release];
 }
 


### PR DESCRIPTION
... also prevents child browser and other plugins from further working

WebKit discarded an uncaught exception in the webView:decidePolicyForNavigationAction:request:frame:decisionListener: delegate: <NSInvalidArgumentException> Application tried to present a nil modal view controller on target

When no account is set up in Email app the "picker" variable is nil and throws the above error. 
