### PR TITLE
Ability to send HTML or an Image using ACTION_SEND

### DIFF
--- a/Android/WebIntent/WebIntent.java
+++ b/Android/WebIntent/WebIntent.java
@@ -122,7 +122,17 @@ public class WebIntent extends Plugin {
 		}
 		for (String key : extras.keySet()) {
 			String value = extras.get(key);
-			i.putExtra(key, value);
+			//If type is text html, the extra text must sent as HTML
+			if (key.equals(Intent.EXTRA_TEXT) && type.equals("text/html")) {
+				i.putExtra(key, Html.fromHtml(value));
+			} else if(key.equals(Intent.EXTRA_STREAM)) {
+				//allowes sharing of images as attachments.
+				//value in this case should be a URI of a file
+				i.putExtra(key, Uri.parse(value));
+			}
+			else {
+				i.putExtra(key, value);
+			}	
 		}
 		this.ctx.startActivity(i);
 	}

--- a/Android/WebIntent/webintent.js
+++ b/Android/WebIntent/webintent.js
@@ -11,6 +11,7 @@ WebIntent.ACTION_SEND = "android.intent.action.SEND";
 WebIntent.ACTION_VIEW= "android.intent.action.VIEW";
 WebIntent.EXTRA_TEXT = "android.intent.extra.TEXT";
 WebIntent.EXTRA_SUBJECT = "android.intent.extra.SUBJECT";
+WebIntent.EXTRA_STREAM = "android.intent.extra.STREAM";
 
 WebIntent.prototype.startActivity = function(params, success, fail) {
 	return PhoneGap.exec(function(args) {


### PR DESCRIPTION
Hi,
I made two small modifications for the WebIntent plugin.
First i added the possibility to use text/html type while sharing an email (Some apps support this, but the gmail app for example, requires the HTML encoded object and not a string).
Example:

```
        var extras = {};
        extras[WebIntent.EXTRA_SUBJECT] = "An HTML-based email";
        extras[WebIntent.EXTRA_TEXT] = "<p>Hello HTML!<br/>Working great</p>.";

        window.plugins.webintent.startActivity({
            action: WebIntent.ACTION_SEND,
            type: 'text/html',
            extras: extras
        }, function() {
            console.log("HTML sent")                
        }, function () {
            alert('Failed to send Email');
        });
```

I also added the possibility to share an image (type image/jpeg, for example) using the EXTRA_STREAM .
An example would be:

```
        var extras = {};
        extras[WebIntent.EXTRA_SUBJECT] = "An Image";
        extras[WebIntent.EXTRA_TEXT] = "Image attached.";
        extras[WebIntent.EXTRA_STREAM] ="file:///sdcard/Image.jpg";

        window.plugins.webintent.startActivity({
            action: WebIntent.ACTION_SEND,
            type: 'image/jpeg',
            extras: extras
        }, function() {
            console.log("Image sent")                
        }, function () {
            alert('Failed to send Image');
        });
```
