### PR TITLE
Adds setCustomVariable functionality to the iPhone and Android Google Analytics plugins

### DIFF
--- a/Android/Analytics/src/com/phonegap/plugins/analytics/GoogleAnalyticsTracker.java
+++ b/Android/Analytics/src/com/phonegap/plugins/analytics/GoogleAnalyticsTracker.java
@@ -19,7 +19,8 @@ import com.phonegap.api.PluginResult.Status;
 public class GoogleAnalyticsTracker extends Plugin {
 	public static final String START = "start";
 	public static final String TRACK_PAGE_VIEW = "trackPageView";
-    public static final String TRACK_EVENT = "trackEvent";
+	public static final String TRACK_EVENT = "trackEvent";
+	public static final String SET_CUSTOM_VARIABLE = "setCustomVariable";
     
 	public static final int DISPATCH_INTERVAL = 20;
 	private com.google.android.apps.analytics.GoogleAnalyticsTracker tracker;
@@ -52,6 +53,12 @@ public class GoogleAnalyticsTracker extends Plugin {
 			} catch (JSONException e) {
 				result = new PluginResult(Status.JSON_EXCEPTION);
 			}
+		} else if (SET_CUSTOM_VARIABLE.equals(action)){
+			try {
+				setCustomVar(data.getInt(0), data.getString(1), data.getString(2), data.getInt(3));
+			} catch (JSONException e) {
+				result = new PluginResult(Status.JSON_EXCEPTION);
+			}
 		} else {
 			result = new PluginResult(Status.INVALID_ACTION);
 		}		
@@ -68,5 +75,9 @@ public class GoogleAnalyticsTracker extends Plugin {
 
 	private void trackEvent(String category, String action, String label, int value){
 		tracker.trackEvent(category, action, label, value);
+	}
+
+	private void setCustomVar(int index, String label, String value, int scope) {
+		tracker.setCustomVar(index, label, value, scope);
 	}
 }

--- a/Android/Analytics/www/analytics.js
+++ b/Android/Analytics/www/analytics.js
@@ -67,7 +67,21 @@ Analytics.prototype.trackEvent = function(category, action, label, value, succes
 				    typeof label === "undefined" ? "" : label, 
 				    (isNaN(parseInt(value,10))) ? 0 : parseInt(value, 10)
 				]);					
-}
+};
+
+Analytics.prototype.setCustomVar = function(index, label, value, scope, successCallback, failureCallback){
+	return PhoneGap.exec(
+				successCallback,			
+				failureCallback,		
+				'GoogleAnalyticsTracker',
+				'setCustomVariable',		
+				[
+				    (isNaN(parseInt(index,10))) ? 0 : parseInt(index, 10),
+				    label,
+				    value,
+				    (isNaN(parseInt(scope,10))) ? 0 : parseInt(scope, 10)
+				]);					
+};
 
 /**
  * Load Analytics

--- a/iPhone/GoogleAnalytics/GoogleAnalyticsPlugin.h
+++ b/iPhone/GoogleAnalytics/GoogleAnalyticsPlugin.h
@@ -21,6 +21,7 @@
 
 - (void) startTrackerWithAccountID:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
 - (void) trackEvent:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+- (void) setCustomVariable:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
 - (void) trackPageview:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
 
 @end

--- a/iPhone/GoogleAnalytics/GoogleAnalyticsPlugin.js
+++ b/iPhone/GoogleAnalytics/GoogleAnalyticsPlugin.js
@@ -16,6 +16,13 @@ GoogleAnalyticsPlugin.prototype.trackEvent = function(category,action,label,valu
 	PhoneGap.exec("GoogleAnalyticsPlugin.trackEvent",options);
 };
 
+GoogleAnalyticsPlugin.prototype.setCustomVariable = function(index,name,value) {
+	var options = {index:index,
+		name:name,
+		value:value};
+	PhoneGap.exec("GoogleAnalyticsPlugin.setCustomVariable",options);
+};
+
 GoogleAnalyticsPlugin.prototype.hitDispatched = function(hitString) {
 	//console.log("hitDispatched :: " + hitString);
 };

--- a/iPhone/GoogleAnalytics/GoogleAnalyticsPlugin.m
+++ b/iPhone/GoogleAnalytics/GoogleAnalyticsPlugin.m
@@ -48,6 +48,28 @@ static const NSInteger kGANDispatchPeriodSec = 10;
 
 }
 
+- (void) setCustomVariable:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options
+{
+    
+	int index = [[options valueForKey:@"index"] intValue];
+	NSString* name = [options valueForKey:@"name"];
+	NSString* value = [options valueForKey:@"value"];
+    
+	NSError *error;
+    
+	if (![[GANTracker sharedTracker] setCustomVariableAtIndex:index 
+                                                         name:name 
+                                                        value:value 
+                                                    withError:&error]) {
+		// Handle error here
+		NSLog(@"GoogleAnalyticsPlugin.setCustonVariable Error::%@",[error localizedDescription]);
+	}
+    
+    
+	NSLog(@"GoogleAnalyticsPlugin.setCustomVariable::%d, %@, %@", index, name, value);
+    
+}
+
 - (void) trackPageview:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options
 {
 	NSString* pageUri = [arguments objectAtIndex:0];


### PR DESCRIPTION
The iOS and Android SDK's for Google Analytics already support the ability to set custom variables, but the PhoneGap plugins didn't yet. I needed this for my project, so I built them. I'd like to add them to the main repo so others can use them.

Thanks!
Chris Downie
