### PR TITLE
support Android 2.1-2.3.0 and fix up readme js example

### DIFF
--- a/Android/SpeechRecognizer/README.md
+++ b/Android/SpeechRecognizer/README.md
@@ -43,7 +43,7 @@ function speechOk(result) {
             requestCode = respObj.speechMatches.requestCode;
             
             for (match in respObj.speechMatches.speechMatch) {
-                console.log("possible match: " + match);
+                console.log("possible match: " + respObj.speechMatches.speechMatch[match]);
                 // regex comes in handy for dealing with these match strings
             }
         }        

--- a/Android/SpeechRecognizer/SpeechRecognizer.java
+++ b/Android/SpeechRecognizer/SpeechRecognizer.java
@@ -57,7 +57,7 @@ public class SpeechRecognizer extends Plugin {
             if (!recognizerPresent) {
                 return new PluginResult(PluginResult.Status.ERROR, NOT_PRESENT_MESSAGE);
             }
-            if (!this.speechRecognizerCallbackId.isEmpty()) {
+            if (!(this.speechRecognizerCallbackId.length() == 0)) {
                 return new PluginResult(PluginResult.Status.ERROR, "Speech recognition is in progress.");
             }
             
@@ -125,7 +125,7 @@ public class SpeechRecognizer extends Plugin {
         intent.putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM);
         if (maxMatches > 0)
             intent.putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, maxMatches);
-        if (!prompt.isEmpty())
+        if (!(prompt.length() == 0))
             intent.putExtra(RecognizerIntent.EXTRA_PROMPT, prompt);
         ctx.startActivityForResult(this, intent, reqCode);
     }


### PR DESCRIPTION
@macdonst -

The java change allows support for Android 2.1 - 2.2 (API 7 - 8) as .isEmpty() only became supported at API 9.

README.md change will log potential speech matches (not index).
