### PR TITLE
Refactored iOS DatePicker plugin

### DIFF
--- a/iPhone/DatePicker/DatePicker.h
+++ b/iPhone/DatePicker/DatePicker.h
@@ -9,16 +9,21 @@
 #import "PGPlugin.h"
 #endif
 
+#ifndef k_DATEPICKER_DATETIME_FORMAT
+#define k_DATEPICKER_DATETIME_FORMAT @"yyyy-MM-dd'T'HH:mm:ss'Z'"
+#endif
 
 @interface DatePicker : PGPlugin <UIActionSheetDelegate> {
 	UIActionSheet *_datePickerSheet;
 	UIDatePicker *_datePicker;
+	NSDateFormatter *_isoDateFormatter;
 	BOOL isVisible;
 
 }
 
 @property (nonatomic, retain) UIActionSheet* datePickerSheet;
 @property (nonatomic, retain) UIDatePicker* datePicker;
+@property (nonatomic, retain) NSDateFormatter* isoDateFormatter;
 
 
 //- (void) prepare:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;

--- a/iPhone/DatePicker/DatePicker.h
+++ b/iPhone/DatePicker/DatePicker.h
@@ -10,9 +10,9 @@
 #endif
 
 
-@interface DatePicker : PGPlugin {
-	UIActionSheet *datePickerSheet;
-	UIDatePicker *datePicker;
+@interface DatePicker : PGPlugin <UIActionSheetDelegate> {
+	UIActionSheet *_datePickerSheet;
+	UIDatePicker *_datePicker;
 	BOOL isVisible;
 
 }

--- a/iPhone/DatePicker/DatePicker.js
+++ b/iPhone/DatePicker/DatePicker.js
@@ -15,11 +15,22 @@ if (typeof PhoneGap !== "undefined") {
      * show - true to show the ad, false to hide the ad
      */
     DatePicker.prototype.show = function(options, cb) {
+        var padDate = function(date) {
+          if (date.length == 1) {
+            return ("0" + date);
+          }
+          return date;
+        };
+
         if (options.date) {
-            options.date = (options.date.getMonth()+1)+"/"+(options.date.getDate())+"/"+(options.date.getFullYear());
+            options.date = options.date.getFullYear() + "-" +
+                           padDate(options.date.getMonth()+1) + "-" +
+                           padDate(options.date.getDate()) +
+                           "T" + padDate(options.date.getHours()) + ":" +
+                           padDate(options.date.getMinutes()) + ":00Z";
         }
         var defaults = {
-            mode: '',
+            mode: 'datetime',
             date: '',
             allowOldDates: true
         }

--- a/iPhone/DatePicker/DatePicker.m
+++ b/iPhone/DatePicker/DatePicker.m
@@ -30,8 +30,6 @@
 {
 	self = (DatePicker *)[super initWithWebView:theWebView];
 
-	NSLog(@"DatePicker refs: %i, datePickerSheet refs: %i, dataPicker refs: %i", [self retainCount], [_datePickerSheet retainCount], [_datePicker retainCount]);
-
 	[self initActionSheet:self];
 
 	[self initActionSheetCloseButton:self.datePickerSheet title:@"Close" target:self action:@selector(dismissActionSheet:)];
@@ -148,16 +146,14 @@
 
 		NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
 		[dateFormatter setTimeZone:[NSTimeZone defaultTimeZone]];
-		[dateFormatter setDateFormat:@"MM/dd/yyyy"];
-		NSDate *date = [dateFormatter dateFromString:dateString];
-		[dateFormatter release];
+		[dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss'Z'"];
+		NSDate *date = [dateFormatter dateFromString:dateString];		
 		datePickerControl.date = date;
 	}
 	else if ([mode isEqualToString:@"time"])
 	{
 		datePickerControl.datePickerMode = UIDatePickerModeTime;
 	}
-
 
 	return [datePickerControl autorelease];
 }

--- a/iPhone/DatePicker/DatePicker.m
+++ b/iPhone/DatePicker/DatePicker.m
@@ -26,28 +26,51 @@
 
 #pragma mark - Public Methods
 
+- (PGPlugin *)initWithWebView:(UIWebView *)theWebView
+{
+	self = (DatePicker *)[super initWithWebView:theWebView];
+
+	NSLog(@"DatePicker refs: %i, datePickerSheet refs: %i, dataPicker refs: %i", [self retainCount], [_datePickerSheet retainCount], [_datePicker retainCount]);
+
+	[self initActionSheet:self];
+
+	[self initActionSheetCloseButton:self.datePickerSheet title:@"Close" target:self action:@selector(dismissActionSheet:)];
+
+	return self;
+}
+
 - (void)show:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options
 {
 	if (isVisible) {
 		return;        
 	}
 
-	[self initActionSheet:self];
-
-	[self initActionSheetCloseButton:self.datePickerSheet title:@"Close" target:self action:@selector(dismissActionSheet:)];
-
-
 	UIDatePicker *datePickerInstance = [[self createDatePicker:CGRectMake(0, 40, 0, 0) options:options] retain];
+	self.datePicker = datePickerInstance;
 	[self.datePickerSheet addSubview:datePickerInstance];
 	[datePickerInstance release];
 
 	[self.datePickerSheet showInView:[[super webView] superview]];	
+	[self.datePickerSheet setBounds:CGRectMake(0, 0, 320, 485)];
 
 	isVisible = YES;
 }
 
 - (void)dismissActionSheet:(id)sender {
 	[self.datePickerSheet dismissWithClickedButtonIndex:0 animated:YES];
+}
+
+- (void) onMemoryWarning
+{
+	// It could be better to close the datepicker before the system
+	// clears memory. But in reality, other non-visible plugins should
+	// be tidying themselves at this point. This could cause a fatal
+	// at runtime.
+	if (isVisible) {
+		return;
+	}
+
+	[self release];
 }
 
 - (void)dealloc
@@ -60,28 +83,24 @@
 
 #pragma mark - UIActionSheetDelegate methods
 
-- (void)willPresentActionSheet:(UIActionSheet *)actionSheet
-{
-	[self.datePickerSheet setBounds:CGRectMake(0, 0, 320, 485)];
-}
-
 - (void)actionSheet:(UIActionSheet *)actionSheet willDismissWithButtonIndex:(NSInteger)buttonIndex
 {
 	NSString* jsCallback = [NSString stringWithFormat:@"window.plugins.datePicker._dateSelected(\"%i\");", (int)[self.datePicker.date timeIntervalSince1970]];
+	NSLog(@"Date: %@", self.datePicker);
+	NSLog(@"%f", [self.datePicker.date timeIntervalSince1970]);
 	[super writeJavascript:jsCallback];
 }
 
 - (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex
 {
 	isVisible = NO;
-	[self release];
 }
 
 #pragma mark - Private Methods
 
 - (void)initActionSheetCloseButton:(UIView *)parentView title:(NSString *)title target:(id)target action:(SEL)action
 {
-	 UISegmentedControl *closeButton = [[UISegmentedControl alloc] initWithItems:[NSArray arrayWithObject:title]];
+	UISegmentedControl *closeButton = [[UISegmentedControl alloc] initWithItems:[NSArray arrayWithObject:title]];
 
 	closeButton.momentary = YES; 
 	closeButton.frame = CGRectMake(260, 7.0f, 50.0f, 30.0f);

--- a/iPhone/DatePicker/DatePicker.m
+++ b/iPhone/DatePicker/DatePicker.m
@@ -154,6 +154,17 @@
 	{
 		datePickerControl.datePickerMode = UIDatePickerModeTime;
 	}
+	else if ([mode isEqualToString:@"datetime"])
+	{
+		datePickerControl.datePickerMode = UIDatePickerModeDateAndTime;
+
+		NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+		[dateFormatter setTimeZone:[NSTimeZone defaultTimeZone]];
+		[dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss'Z'"];
+		NSDate *date = [dateFormatter dateFromString:dateString];		
+		datePickerControl.date = date;
+
+	}
 
 	return [datePickerControl autorelease];
 }


### PR DESCRIPTION
This is a major refactor of the iOS DatePicker plugin to make it play nice with iOS. The previous version was not implementing the standard Objective-C patterns for memory management or delegation. This refactor provides the following;
- Better memory management of all native iOS components (not using ARC)
- Uses the UIActionSheetDelegate protocol to send selected date back to PhoneGap
- Unloads the logic from the Back button segmented control
- Uses ISO standard dates for communication between Objective C and JS to ensure no ambiguity
- If no _mode_ is sent to the control, UIDatePickerModeDateAndTime is used
