### PR TITLE
Fixed overly eager alert in ChildBrowser

### DIFF
--- a/iPhone/ChildBrowser/ChildBrowserViewController.m
+++ b/iPhone/ChildBrowser/ChildBrowserViewController.m
@@ -220,18 +220,27 @@
 }
 
 - (void)webView:(UIWebView *)wv didFailLoadWithError:(NSError *)error {
-    NSLog (@"webView:didFailLoadWithError");
     [spinner stopAnimating];
-    addressLabel.text = @"Failed";
     if (error != NULL) {
-        UIAlertView *errorAlert = [[UIAlertView alloc]
-                                   initWithTitle: [error localizedDescription]
-                                   message: [error localizedFailureReason]
-                                   delegate:nil
-                                   cancelButtonTitle:@"OK"
-                                   otherButtonTitles:nil];
-        [errorAlert show];
-        [errorAlert release];
+        //bugfix: https://discussions.apple.com/thread/1727260
+        if (error.code == NSURLErrorCancelled) {
+            
+            NSLog(@"webview:loading cancelled by user");
+            return;
+            
+        }else{
+            NSLog (@"webView:didFailLoadWithError");
+            addressLabel.text = @"Failed";
+        
+            UIAlertView *errorAlert = [[UIAlertView alloc]
+                                       initWithTitle: [error localizedDescription]
+                                       message: [error localizedFailureReason]
+                                       delegate:nil
+                                       cancelButtonTitle:@"OK"
+                                       otherButtonTitles:nil];
+            [errorAlert show];
+            [errorAlert release];
+        }
     }
 }
 


### PR DESCRIPTION
When the user clicked "done" before the page was fully loaded, an error alert was shown, which is extremely intrusive and also unnecessary.

I solved this by checking whether the error code equals to NSURLErrorCancelled and letting it silently fail, otherwise it falls back to the alertion mechanism.

Found answer here : https://discussions.apple.com/thread/1727260?start=0&tstart=0
