### PR TITLE
Additional input type for messagebox plugin.

### DIFF
--- a/iPhone/MessageBox/MessageBox.m
+++ b/iPhone/MessageBox/MessageBox.m
@@ -55,6 +55,8 @@
 		[textField setPlaceholder:placeholder];
 	}
 	if ([[type lowercaseString] isEqualToString:@"password"]) [textField setSecureTextEntry:YES];
+        if ([[type lowercaseString] isEqualToString:@"decimalpad"]) [textField setKeyboardType:UIKeyboardTypeDecimalPad];
+
 	[prompt addSubview:textField];
 	
 	// Position fix for iOS < 4


### PR DESCRIPTION
Added additional type: "decimalpad" When using the option {type: 'decimalpad'}, the iOS UIKeyboardTypeDecimalPad will be shown instead of the standard qwerty. 
