### PR TITLE
Allow video to be played when video in assets folder

### DIFF
--- a/Android/VideoPlayer/README.md
+++ b/Android/VideoPlayer/README.md
@@ -36,8 +36,9 @@ Sample use:
 
     window.plugins.videoPlayer.play("http://path.to.my/video.mp4");
     window.plugins.videoPlayer.play("file:///path/to/my/video.mp4");
+    window.plugins.videoPlayer.play("file:///android_assets/www/path/to/my/video.mp4");
 
-Note: You cannot play a video from the assets folder on Android.
+Note: When playing video from the assets folder, the video is first copied to internal storage with MODE_WORLD_READABLE.
 
 ## RELEASE NOTES ##
 


### PR DESCRIPTION
I've added in functionality so that if a video is in the assets folder, it is copied to internal storage and then played from there.

It checks to see if the file path has 'android_assets' in it and then copies the file to internal storage, changes the uri to point to the temporary copy, and plays it.

I've also added a comment about it in the README.

Cheers
