### PR TITLE
Improve childbrowser API consistency between Android and iOS

### DIFF
--- a/Android/ChildBrowser/www/childbrowser.js
+++ b/Android/ChildBrowser/www/childbrowser.js
@@ -78,6 +78,7 @@ ChildBrowser.prototype._onError = function(data) {
  * Maintain API consistency with iOS
  */
 ChildBrowser.prototype.install = function(){
+    return window.plugins.childBrowser;
 };
 
 /**

--- a/Android/ChildBrowser/www/childbrowser.js
+++ b/Android/ChildBrowser/www/childbrowser.js
@@ -77,7 +77,7 @@ ChildBrowser.prototype._onError = function(data) {
 /**
  * Maintain API consistency with iOS
  */
-ChildBrowser.prototype.install = function(){
+ChildBrowser.install = function(){
     return window.plugins.childBrowser;
 };
 


### PR DESCRIPTION
for complete API consistency the 'install' method should return the browser object.  Otherwise the result of the same function in each api is different.
