### PR TITLE
Android Webintents Emailaddress

### DIFF
--- a/Android/WebIntent/WebIntent.java
+++ b/Android/WebIntent/WebIntent.java
@@ -130,8 +130,10 @@ public class WebIntent extends Plugin {
 				//allowes sharing of images as attachments.
 				//value in this case should be a URI of a file
 				i.putExtra(key, Uri.parse(value));
-			}
-			else {
+			} else if(key.equals(Intent.EXTRA_EMAIL)){
+				//allows to add the email address of the receiver
+				i.putExtra(Intent.EXTRA_EMAIL, new String[]{value});
+			} else {
 				i.putExtra(key, value);
 			}	
 		}

--- a/Android/WebIntent/webintent.js
+++ b/Android/WebIntent/webintent.js
@@ -12,6 +12,7 @@ WebIntent.ACTION_VIEW= "android.intent.action.VIEW";
 WebIntent.EXTRA_TEXT = "android.intent.extra.TEXT";
 WebIntent.EXTRA_SUBJECT = "android.intent.extra.SUBJECT";
 WebIntent.EXTRA_STREAM = "android.intent.extra.STREAM";
+WebIntent.EXTRA_EMAIL = "android.intent.extra.EMAIL";
 
 WebIntent.prototype.startActivity = function(params, success, fail) {
 	return PhoneGap.exec(function(args) {


### PR DESCRIPTION
Added the "android.intent.extra.EMAIL"-Intent-Extra.
Allows to specify the emailaddress of the receiver for an email intent.
Usage is shown in the adapted sendEmail function:

<pre>
function sendEmail(receiver, subject, body){
    var extras = {};
    extras[WebIntent.EXTRA_EMAIL] = receiver;
    extras[WebIntent.EXTRA_SUBJECT] = subject;
    extras[WebIntent.EXTRA_TEXT] = body;
    
    window.plugins.webintent.startActivity({ 
        action: WebIntent.ACTION_SEND,
        type: 'message/rfc822', 
        extras: extras 
      }, 
      function() {}, 
      function() {
        alert('Failed to send email via Android Intent');
      }
    );
}
</pre>
