### PR TITLE
Updated Application Preferences Iphone Plugin for Cordova (Phonegap 1.5)

### DIFF
--- a/iPhone/ApplicationPreferences/README.md
+++ b/iPhone/ApplicationPreferences/README.md
@@ -28,6 +28,12 @@ A full set example could be:
 	    }
 	);
 
+## Registering the plugin ## 
+
+1. Opne Cordovo.plist file in Xcode
+2. To the plugins Dictionary add a new String item
+3. Name and value of the item would be "applicationPreferences"
+
 
 ## BUGS AND CONTRIBUTIONS ##
 The latest release version is available [on GitHub](https://github.com/ttopholm/phonegap-plugins/)

--- a/iPhone/ApplicationPreferences/applicationPreferences.h
+++ b/iPhone/ApplicationPreferences/applicationPreferences.h
@@ -8,9 +8,9 @@
 
 #import <Foundation/Foundation.h>
 
-#import <PhoneGap/PGPlugin.h>
+#import <Cordova/CDVPlugin.h>
 
-@interface applicationPreferences : PGPlugin 
+@interface applicationPreferences : CDVPlugin 
 {
 
 }

--- a/iPhone/ApplicationPreferences/applicationPreferences.js
+++ b/iPhone/ApplicationPreferences/applicationPreferences.js
@@ -5,7 +5,7 @@ applicationPreferences.prototype.get = function(key,success,fail)
 {
     var args = {};
     args.key = key;
-    PhoneGap.exec(success,fail,"applicationPreferences","getSetting",[args]);
+    Cordova.exec(success,fail,"applicationPreferences","getSetting",[args]);
 };
 
 applicationPreferences.prototype.set = function(key,value,success,fail) 
@@ -13,10 +13,10 @@ applicationPreferences.prototype.set = function(key,value,success,fail)
     var args = {};
     args.key = key;
     args.value = value;
-    PhoneGap.exec(success,fail,"applicationPreferences","setSetting",[args]);
+    Cordova.exec(success,fail,"applicationPreferences","setSetting",[args]);
 };
 
-PhoneGap.addConstructor(function() 
+Cordova.addConstructor(function() 
 {
 	if(!window.plugins)
 	{

--- a/iPhone/ApplicationPreferences/applicationPreferences.m
+++ b/iPhone/ApplicationPreferences/applicationPreferences.m
@@ -21,7 +21,7 @@
 
         
 		NSString *settingsName = [options objectForKey:@"key"];
-        PluginResult* result = nil;
+        CDVPluginResult* result = nil;
 	
 		@try 
 		{
@@ -35,12 +35,12 @@
 				if (returnVar == nil) 
 					@throw [NSException exceptionWithName:nil reason:@"Key not found" userInfo:nil];;
 			}
-			result = [PluginResult resultWithStatus:PGCommandStatus_OK messageAsString:returnVar];
+			result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:returnVar];
 			jsString = [result toSuccessCallbackString:callbackID];		
 		}
 		@catch (NSException * e) 
 		{
-			result = [PluginResult resultWithStatus:PGCommandStatus_NO_RESULT messageAsString:[e reason]];
+			result = [CDVPluginResult resultWithStatus:CDVCommandStatus_NO_RESULT messageAsString:[e reason]];
             jsString = [result toErrorCallbackString:callbackID];
 		}
 		@finally 
@@ -53,7 +53,7 @@
 {
     NSString* callbackID = [arguments pop];
 	NSString* jsString;    
-    PluginResult* result;
+    CDVPluginResult* result;
 
     NSString *settingsName = [options objectForKey:@"key"];
     NSString *settingsValue = [options objectForKey:@"value"];
@@ -62,13 +62,13 @@
     @try 
     {
         [[NSUserDefaults standardUserDefaults] setValue:settingsValue forKey:settingsName];
-        result = [PluginResult resultWithStatus:PGCommandStatus_OK];
+        result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
         jsString = [result toSuccessCallbackString:callbackID];
 			
     }
     @catch (NSException * e) 
     {
-        result = [PluginResult resultWithStatus:PGCommandStatus_NO_RESULT messageAsString:[e reason]];
+        result = [CDVPluginResult resultWithStatus:CDVCommandStatus_NO_RESULT messageAsString:[e reason]];
         jsString = [result toErrorCallbackString:callbackID];
     }
     @finally 


### PR DESCRIPTION
All references to Phonegap have been updated to Cordova. All clases which started with PG have been updated to CDV. Tested plugin on Mac OSx Lion 1.7.3. Also updated Readme to show how to update Cordov.plist file and register the plugin with phonegap
