### PR TITLE
Added new `iOS/ProgressHud` plugin for Cordova-1.6+.

### DIFF
--- a/iOS/ProgressHud/ProgressHud.h
+++ b/iOS/ProgressHud/ProgressHud.h
@@ -1,0 +1,31 @@
+//
+//  ProgressHud.m
+//  
+// Created by Olivier Louvignes on 04/25/2012.
+//
+// Copyright 2011 Olivier Louvignes. All rights reserved.
+// MIT Licensed
+
+#ifdef CORDOVA_FRAMEWORK
+#import <CORDOVA/CDVPlugin.h>
+#else
+#import "CDVPlugin.h"
+#endif
+
+#import "MBProgressHUD.h"
+
+@interface ProgressHud : CDVPlugin {
+	
+	NSString* callbackID;
+	
+}
+
+@property (nonatomic, copy) NSString* callbackID;
+@property (nonatomic, retain) MBProgressHUD* progressHUD;
+
+//Instance Method  
+- (void) show:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+- (void) set:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+- (void) hide:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+
+@end

--- a/iOS/ProgressHud/ProgressHud.js
+++ b/iOS/ProgressHud/ProgressHud.js
@@ -1,0 +1,75 @@
+//
+//  ProgressHud.js
+//
+// Created by Olivier Louvignes on 04/25/2012.
+//
+// Copyright 2011 Olivier Louvignes. All rights reserved.
+// MIT Licensed
+
+function ProgressHud() {}
+
+ProgressHud.prototype.show = function(options, callback) {
+	if(!options) options = {};
+	var scope = options.scope || null;
+	delete options.scope;
+
+	var service = 'ProgressHud',
+		action = 'show',
+		callbackId = service + (cordova.callbackId + 1);
+
+	var config = {
+		mode: options.mode || 'indeterminate',
+		labelText: options.labelText || 'Loading...',
+		detailsLabelText: options.detailsLabelText || '',
+		progress: options.progress || 0
+	};
+
+	var _callback = function(result) {
+		if(typeof callback == 'function') callback.apply(scope, arguments);
+	};
+
+	return cordova.exec(_callback, _callback, service, action, [config]);
+
+};
+
+ProgressHud.prototype.set = function(options, callback) {
+	if(!options) options = {};
+	var scope = options.scope || null;
+	delete options.scope;
+
+	var service = 'ProgressHud',
+		action = 'set',
+		callbackId = service + (cordova.callbackId + 1);
+
+	var _callback = function(result) {
+		if(typeof callback == 'function') callback.apply(scope, arguments);
+	};
+
+	return cordova.exec(_callback, _callback, service, action, [options]);
+
+};
+
+
+ProgressHud.prototype.hide = function(options, callback) {
+	if(!options) options = {};
+	var scope = options.scope || null;
+	delete options.scope;
+
+	var service = 'ProgressHud',
+		action = 'hide',
+		callbackId = service + (cordova.callbackId + 1);
+
+	var config = {};
+
+	var _callback = function(result) {
+		if(typeof callback == 'function') callback.apply(scope, arguments);
+	};
+
+	return cordova.exec(_callback, _callback, service, action, [config]);
+
+};
+
+cordova.addConstructor(function() {
+	if(!window.plugins) window.plugins = {};
+	window.plugins.progressHud = new ProgressHud();
+});

--- a/iOS/ProgressHud/ProgressHud.m
+++ b/iOS/ProgressHud/ProgressHud.m
@@ -1,0 +1,89 @@
+//
+//  ProgressHud.m
+//  
+// Created by Olivier Louvignes on 04/25/2012.
+//
+// Copyright 2011 Olivier Louvignes. All rights reserved.
+// MIT Licensed
+
+#import "ProgressHud.h"
+
+@implementation ProgressHud 
+
+@synthesize callbackID = _callbackID;
+@synthesize progressHUD = _progressHUD;
+
+-(void)show:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options  
+{
+	
+	//NSLog(@"options: %@", options);
+	//NSLog(@"arguments: %@", arguments);
+	
+	self.progressHUD = [MBProgressHUD showHUDAddedTo:self.webView.superview animated:YES];
+	self.progressHUD.mode = MBProgressHUDModeIndeterminate;
+
+	[self set:arguments withDict:options];
+	
+}
+
+-(void)set:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options  
+{
+	
+	//NSLog(@"options: %@", options);
+	//NSLog(@"arguments: %@", arguments);
+	
+	// The first argument in the arguments parameter is the callbackID.
+	// We use this to send data back to the successCallback or failureCallback
+	// through PluginResult.
+	self.callbackID = [arguments pop];
+	
+	// Compiling options with defaults
+	NSString *mode = [options objectForKey:@"mode"] ?: nil;
+	NSString *labelText = [options objectForKey:@"labelText"] ?: nil;
+	NSString *detailsLabelText = [options objectForKey:@"detailsLabelText"] ?: nil;
+	float progress = [[options objectForKey:@"progress"] floatValue] ?: 0;
+	
+	if([mode isEqualToString:@"indeterminate"]) self.progressHUD.mode = MBProgressHUDModeIndeterminate;
+	else if([mode isEqualToString:@"determinate"]) self.progressHUD.mode = MBProgressHUDModeDeterminate;
+	else if([mode isEqualToString:@"annular-determinate"]) self.progressHUD.mode = MBProgressHUDModeAnnularDeterminate;
+
+	if(labelText) self.progressHUD.labelText = labelText;
+	if(detailsLabelText) self.progressHUD.detailsLabelText= detailsLabelText;
+	if(progress) self.progressHUD.progress = progress;
+	
+	// Build returned result
+	NSMutableDictionary *result = [[NSMutableDictionary alloc] init];
+	// Create Plugin Result
+	CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:result];
+	//Call  the Success Javascript function
+	[self writeJavascript: [pluginResult toSuccessCallbackString:self.callbackID]];
+	
+}
+
+-(void)hide:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options  
+{
+	
+	//NSLog(@"options: %@", options);
+	//NSLog(@"arguments: %@", arguments);
+	
+	// The first argument in the arguments parameter is the callbackID.
+	// We use this to send data back to the successCallback or failureCallback
+	// through PluginResult.
+	self.callbackID = [arguments pop];
+
+	// Hide HUD
+	[MBProgressHUD hideHUDForView:self.webView.superview animated:YES];
+	
+	// Build returned result
+	NSMutableDictionary *result = [[NSMutableDictionary alloc] init];
+	// Create Plugin Result
+	CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:result];
+	//Call  the Success Javascript function
+	[self writeJavascript: [pluginResult toSuccessCallbackString:self.callbackID]];
+	
+	// Release objects
+	[self.progressHUD release];
+	
+}
+
+@end

--- a/iOS/ProgressHud/README.md
+++ b/iOS/ProgressHud/README.md
@@ -1,0 +1,79 @@
+# Cordova ProgressHud Plugin #
+by `Olivier Louvignes`
+
+## DESCRIPTION ##
+
+* This plugin provides a simple way to use a native loading component from IOS. It does comply with the latest (future-2.x) cordova standards.
+
+* It relies on `[MBProgressHUD](https://github.com/jdg/MBProgressHUD)` to work (MIT license, included in ./libs).
+
+## SETUP ##
+
+Using this plugin requires [Cordova iOS](https://github.com/apache/incubator-cordova-ios).
+
+1. Make sure your Xcode project has been [updated for Cordova](https://github.com/apache/incubator-cordova-ios/blob/master/guides/Cordova%20Upgrade%20Guide.md)
+2. Drag and drop the `ProgressHud` folder from Finder to your Plugins folder in XCode, using "Create groups for any added folders"
+3. Add the .js files to your `www` folder on disk, and add reference(s) to the .js files using <script> tags in your html file(s)
+
+    <script type="text/javascript" src="/js/plugins/ProgressHud.js"></script>
+
+4. Add new entry with key `ProgressHud` and value `ProgressHud` to `Plugins` in `Cordova.plist/Cordova.plist`
+
+## JAVASCRIPT INTERFACE ##
+
+    // After device ready, create a local alias
+    var progressHud = window.plugins.progressHud;
+
+    // Complex example with loading
+    progressHud.show({mode: "determinate", progress:0, labelText: 'Loading...', detailsLabelText: 'Connecting...'}, function() {
+        console.warn('show(), arguments=' + Array.prototype.slice.call(arguments).join(', '));
+    });
+
+    var interval = setInterval(function() {
+
+        i++;
+
+        if(i > n) {
+            progressHud.hide();
+            return clearInterval(interval);
+        }
+
+        var progress = Math.round((i / n) * 100) / 100,
+            detailsLabelText = 'Processing ' + i + '/' + n;
+        if (i == n) {
+            detailsLabelText = 'Finalizing...'
+        }
+
+        progressHud.set({progress: progress, detailsLabelText: detailsLabelText});
+
+    }, 1000);
+
+* Check [source](http://github.com/mgcrea/phonegap-plugins/tree/master/iOS/ProgressHud/ProgressHud.js) for additional configuration.
+
+## BUGS AND CONTRIBUTIONS ##
+
+Patches welcome! Send a pull request. Since this is not a part of Cordova Core (which requires a CLA), this should be easier.
+
+Post issues on [Github](https://github.com/phonegap/phonegap-plugins/issues)
+
+The latest code (my fork) will always be [here](http://github.com/mgcrea/phonegap-plugins/tree/master/iOS/ProgressHud)
+
+## LICENSE ##
+
+Copyright 2012 Olivier Louvignes. All rights reserved.
+
+The MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## CREDITS ##
+
+@RandyMcMillan - Added Initial Cordova 1.5 support - 2012
+
+Inspired by :
+
+* [MBProgressHUD project](https://github.com/jdg/MBProgressHUD)

--- a/iOS/ProgressHud/libs/MBProgressHUD.h
+++ b/iOS/ProgressHud/libs/MBProgressHUD.h
@@ -1,0 +1,374 @@
+//
+//  MBProgressHUD.h
+//  Version 0.5
+//  Created by Matej Bukovinski on 2.4.09.
+//
+
+// This code is distributed under the terms and conditions of the MIT license. 
+
+// Copyright (c) 2011 Matej Bukovinski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <CoreGraphics/CoreGraphics.h>
+
+@protocol MBProgressHUDDelegate;
+
+
+typedef enum {
+	/** Progress is shown using an UIActivityIndicatorView. This is the default. */
+	MBProgressHUDModeIndeterminate,
+	/** Progress is shown using a round, pie-chart like, progress view. */
+	MBProgressHUDModeDeterminate,
+	/** Progress is shown using a ring-shaped progress view. */
+	MBProgressHUDModeAnnularDeterminate,
+	/** Shows a custom view */
+	MBProgressHUDModeCustomView,
+	/** Shows only labels */
+	MBProgressHUDModeText
+} MBProgressHUDMode;
+
+typedef enum {
+	/** Opacity animation */
+	MBProgressHUDAnimationFade,
+	/** Opacity + scale animation */
+	MBProgressHUDAnimationZoom
+} MBProgressHUDAnimation;
+
+
+#ifndef MB_STRONG
+#if __has_feature(objc_arc)
+	#define MB_STRONG strong
+#else
+	#define MB_STRONG retain
+#endif
+#endif
+
+#ifndef MB_WEAK
+#if __has_feature(objc_arc_weak)
+	#define MB_WEAK weak
+#elif __has_feature(objc_arc)
+	#define MB_WEAK unsafe_unretained
+#else
+	#define MB_WEAK assign
+#endif
+#endif
+
+
+/** 
+ * Displays a simple HUD window containing a progress indicator and two optional labels for short messages.
+ *
+ * This is a simple drop-in class for displaying a progress HUD view similar to Apple's private UIProgressHUD class.
+ * The MBProgressHUD window spans over the entire space given to it by the initWithFrame constructor and catches all
+ * user input on this region, thereby preventing the user operations on components below the view. The HUD itself is
+ * drawn centered as a rounded semi-transparent view which resizes depending on the user specified content.
+ *
+ * This view supports four modes of operation:
+ * - MBProgressHUDModeIndeterminate - shows a UIActivityIndicatorView
+ * - MBProgressHUDModeDeterminate - shows a custom round progress indicator
+ * - MBProgressHUDModeAnnularDeterminate - shows a custom annular progress indicator
+ * - MBProgressHUDModeCustomView - shows an arbitrary, user specified view (@see customView)
+ *
+ * All three modes can have optional labels assigned:
+ * - If the labelText property is set and non-empty then a label containing the provided content is placed below the
+ *   indicator view.
+ * - If also the detailsLabelText property is set then another label is placed below the first label.
+ */
+@interface MBProgressHUD : UIView
+
+/**
+ * Creates a new HUD, adds it to provided view and shows it. The counterpart to this method is hideHUDForView:animated:.
+ * 
+ * @param view The view that the HUD will be added to
+ * @param animated If set to YES the HUD will appear using the current animationType. If set to NO the HUD will not use
+ * animations while appearing.
+ * @return A reference to the created HUD.
+ *
+ * @see hideHUDForView:animated:
+ * @see animationType
+ */
++ (MBProgressHUD *)showHUDAddedTo:(UIView *)view animated:(BOOL)animated;
+
+/**
+ * Finds the top-most HUD subview and hides it. The counterpart to this method is showHUDAddedTo:animated:.
+ *
+ * @param view The view that is going to be searched for a HUD subview.
+ * @param animated If set to YES the HUD will disappear using the current animationType. If set to NO the HUD will not use
+ * animations while disappearing.
+ * @return YES if a HUD was found and removed, NO otherwise. 
+ *
+ * @see showHUDAddedTo:animated:
+ * @see animationType
+ */
++ (BOOL)hideHUDForView:(UIView *)view animated:(BOOL)animated;
+
+/**
+ * Finds all the HUD subviews and hides them. 
+ *
+ * @param view The view that is going to be searched for HUD subviews.
+ * @param animated If set to YES the HUDs will disappear using the current animationType. If set to NO the HUDs will not use
+ * animations while disappearing.
+ * @return the number of HUDs found and removed.
+ *
+ * @see hideAllHUDForView:animated:
+ * @see animationType
+ */
++ (NSUInteger)hideAllHUDsForView:(UIView *)view animated:(BOOL)animated;
+
+/**
+ * Finds the top-most HUD subview and returns it. 
+ *
+ * @param view The view that is going to be searched.
+ * @return A reference to the last HUD subview discovered.
+ */
++ (MBProgressHUD *)HUDForView:(UIView *)view;
+
+/**
+ * Finds all HUD subviews and returns them.
+ *
+ * @param view The view that is going to be searched.
+ * @return All found HUD views (array of MBProgressHUD objects).
+ */
++ (NSArray *)allHUDsForView:(UIView *)view;
+
+/** 
+ * Display the HUD. You need to make sure that the main thread completes its run loop soon after this method call so
+ * the user interface can be updated. Call this method when your task is already set-up to be executed in a new thread
+ * (e.g., when using something like NSOperation or calling an asynchronous call like NSURLRequest).
+ *
+ * @param animated If set to YES the HUD will appear using the current animationType. If set to NO the HUD will not use
+ * animations while appearing.
+ *
+ * @see animationType
+ */
+- (void)show:(BOOL)animated;
+
+/** 
+ * Hide the HUD. This still calls the hudWasHidden: delegate. This is the counterpart of the show: method. Use it to
+ * hide the HUD when your task completes.
+ *
+ * @param animated If set to YES the HUD will disappear using the current animationType. If set to NO the HUD will not use
+ * animations while disappearing.
+ *
+ * @see animationType
+ */
+- (void)hide:(BOOL)animated;
+
+/** 
+ * Hide the HUD after a delay. This still calls the hudWasHidden: delegate. This is the counterpart of the show: method. Use it to
+ * hide the HUD when your task completes.
+ *
+ * @param animated If set to YES the HUD will disappear using the current animationType. If set to NO the HUD will not use
+ * animations while disappearing.
+ * @param delay Delay in secons until the HUD is hidden.
+ *
+ * @see animationType
+ */
+- (void)hide:(BOOL)animated afterDelay:(NSTimeInterval)delay;
+
+/** 
+ * Shows the HUD while a background task is executing in a new thread, then hides the HUD.
+ *
+ * This method also takes care of autorelease pools so your method does not have to be concerned with setting up a
+ * pool.
+ *
+ * @param method The method to be executed while the HUD is shown. This method will be executed in a new thread.
+ * @param target The object that the target method belongs to.
+ * @param object An optional object to be passed to the method.
+ * @param animated If set to YES the HUD will (dis)appear using the current animationType. If set to NO the HUD will not use
+ * animations while (dis)appearing.
+ */
+- (void)showWhileExecuting:(SEL)method onTarget:(id)target withObject:(id)object animated:(BOOL)animated;
+
+/** 
+ * Initializes the HUD with the window's bounds. Calls the designated constructor with
+ * window.bounds as the parameter.
+ *
+ * @param window The window instance that will provide the bounds for the HUD. Should be the same instance as
+ * the HUD's superview (i.e., the window that the HUD will be added to).
+ */
+- (id)initWithWindow:(UIWindow *)window;
+
+/**
+ * Initializes the HUD with the view's bounds. Calls the designated constructor with
+ * view.bounds as the parameter
+ * 
+ * @param view The view instance that will provide the bounds for the HUD. Should be the same instance as
+ * the HUD's superview (i.e., the view that the HUD will be added to).
+ */
+- (id)initWithView:(UIView *)view;
+
+/** 
+ * MBProgressHUD operation mode. The default is MBProgressHUDModeIndeterminate.
+ *
+ * @see MBProgressHUDMode
+ */
+@property (assign) MBProgressHUDMode mode;
+
+/**
+ * The animation type that should be used when the HUD is shown and hidden. 
+ *
+ * @see MBProgressHUDAnimation
+ */
+@property (assign) MBProgressHUDAnimation animationType;
+
+/**
+ * The UIView (e.g., a UIImageView) to be shown when the HUD is in MBProgressHUDModeCustomView.
+ * For best results use a 37 by 37 pixel view (so the bounds match the built in indicator bounds). 
+ */
+@property (MB_STRONG) UIView *customView;
+
+/** 
+ * The HUD delegate object. 
+ *
+ * @see MBProgressHUDDelegate
+ */
+@property (MB_WEAK) id<MBProgressHUDDelegate> delegate;
+
+/** 
+ * An optional short message to be displayed below the activity indicator. The HUD is automatically resized to fit
+ * the entire text. If the text is too long it will get clipped by displaying "..." at the end. If left unchanged or
+ * set to @"", then no message is displayed.
+ */
+@property (copy) NSString *labelText;
+
+/** 
+ * An optional details message displayed below the labelText message. This message is displayed only if the labelText
+ * property is also set and is different from an empty string (@""). The details text can span multiple lines. 
+ */
+@property (copy) NSString *detailsLabelText;
+
+/** 
+ * The opacity of the HUD window. Defaults to 0.9 (90% opacity). 
+ */
+@property (assign) float opacity;
+
+/** 
+ * The x-axis offset of the HUD relative to the centre of the superview. 
+ */
+@property (assign) float xOffset;
+
+/** 
+ * The y-ayis offset of the HUD relative to the centre of the superview. 
+ */
+@property (assign) float yOffset;
+
+/**
+ * The amounth of space between the HUD edge and the HUD elements (labels, indicators or custom views). 
+ * Defaults to 20.0
+ */
+@property (assign) float margin;
+
+/** 
+ * Cover the HUD background view with a radial gradient. 
+ */
+@property (assign) BOOL dimBackground;
+
+/*
+ * Grace period is the time (in seconds) that the invoked method may be run without 
+ * showing the HUD. If the task finishes before the grace time runs out, the HUD will
+ * not be shown at all. 
+ * This may be used to prevent HUD display for very short tasks.
+ * Defaults to 0 (no grace time).
+ * Grace time functionality is only supported when the task status is known!
+ * @see taskInProgress
+ */
+@property (assign) float graceTime;
+
+/**
+ * The minimum time (in seconds) that the HUD is shown. 
+ * This avoids the problem of the HUD being shown and than instantly hidden.
+ * Defaults to 0 (no minimum show time).
+ */
+@property (assign) float minShowTime;
+
+/**
+ * Indicates that the executed operation is in progress. Needed for correct graceTime operation.
+ * If you don't set a graceTime (different than 0.0) this does nothing.
+ * This property is automatically set when using showWhileExecuting:onTarget:withObject:animated:.
+ * When threading is done outside of the HUD (i.e., when the show: and hide: methods are used directly),
+ * you need to set this property when your task starts and completes in order to have normal graceTime 
+ * functionality.
+ */
+@property (assign) BOOL taskInProgress;
+
+/**
+ * Removes the HUD from its parent view when hidden. 
+ * Defaults to NO. 
+ */
+@property (assign) BOOL removeFromSuperViewOnHide;
+
+/** 
+ * Font to be used for the main label. Set this property if the default is not adequate. 
+ */
+@property (MB_STRONG) UIFont* labelFont;
+
+/** 
+ * Font to be used for the details label. Set this property if the default is not adequate. 
+ */
+@property (MB_STRONG) UIFont* detailsLabelFont;
+
+/** 
+ * The progress of the progress indicator, from 0.0 to 1.0. Defaults to 0.0. 
+ */
+@property (assign) float progress;
+
+/**
+ * The minimum size of the HUD bezel. Defaults to CGSizeZero (no minimum size).
+ */
+@property (assign) CGSize minSize;
+
+/**
+ * Force the HUD dimensions to be equal if possible. 
+ */
+@property (assign, getter = isSquare) BOOL square;
+
+@end
+
+
+@protocol MBProgressHUDDelegate <NSObject>
+
+@optional
+
+/** 
+ * Called after the HUD was fully hidden from the screen. 
+ */
+- (void)hudWasHidden:(MBProgressHUD *)hud;
+
+@end
+
+
+/**
+ * A progress view for showing definite progress by filling up a circle (pie chart).
+ */
+@interface MBRoundProgressView : UIView 
+
+/**
+ * Progress (0.0 to 1.0)
+ */
+@property (nonatomic, assign) float progress;
+
+/*
+ * Display mode - NO = round or YES = annular. Defaults to round.
+ */
+@property (nonatomic, assign, getter = isAnnular) BOOL annular;
+
+@end

--- a/iOS/ProgressHud/libs/MBProgressHUD.m
+++ b/iOS/ProgressHud/libs/MBProgressHUD.m
@@ -1,0 +1,751 @@
+//
+// MBProgressHUD.m
+// Version 0.5
+// Created by Matej Bukovinski on 2.4.09.
+//
+
+#import "MBProgressHUD.h"
+
+
+#if __has_feature(objc_arc)
+	#define MB_AUTORELEASE(exp) exp
+	#define MB_RELEASE(exp) exp
+	#define MB_RETAIN(exp) exp
+#else
+	#define MB_AUTORELEASE(exp) [exp autorelease]
+	#define MB_RELEASE(exp) [exp release]
+	#define MB_RETAIN(exp) [exp retain]
+#endif
+
+
+static const CGFloat kPadding = 4.f;
+static const CGFloat kLabelFontSize = 16.f;
+static const CGFloat kDetailsLabelFontSize = 12.f;
+
+
+@interface MBProgressHUD ()
+
+- (void)setupLabels;
+- (void)registerForKVO;
+- (void)unregisterFromKVO;
+- (NSArray *)observableKeypaths;
+- (void)registerForNotifications;
+- (void)unregisterFromNotifications;
+- (void)updateUIForKeypath:(NSString *)keyPath;
+- (void)hideUsingAnimation:(BOOL)animated;
+- (void)showUsingAnimation:(BOOL)animated;
+- (void)done;
+- (void)updateIndicators;
+- (void)handleGraceTimer:(NSTimer *)theTimer;
+- (void)handleMinShowTimer:(NSTimer *)theTimer;
+- (void)setTransformForCurrentOrientation:(BOOL)animated;
+- (void)cleanUp;
+- (void)launchExecution;
+- (void)deviceOrientationDidChange:(NSNotification *)notification;
+- (void)hideDelayed:(NSNumber *)animated;
+
+@property (MB_STRONG) UIView *indicator;
+@property (MB_STRONG) NSTimer *graceTimer;
+@property (MB_STRONG) NSTimer *minShowTimer;
+@property (MB_STRONG) NSDate *showStarted;
+@property (assign) CGSize size;
+
+@end
+
+
+@implementation MBProgressHUD {
+	BOOL useAnimation;
+	SEL methodForExecution;
+	id targetForExecution;
+	id objectForExecution;
+	UILabel *label;
+	UILabel *detailsLabel;
+	BOOL isFinished;
+	CGAffineTransform rotationTransform;
+}
+
+#pragma mark - Properties
+
+@synthesize animationType;
+@synthesize delegate;
+@synthesize opacity;
+@synthesize labelFont;
+@synthesize detailsLabelFont;
+@synthesize indicator;
+@synthesize xOffset;
+@synthesize yOffset;
+@synthesize minSize;
+@synthesize square;
+@synthesize margin;
+@synthesize dimBackground;
+@synthesize graceTime;
+@synthesize minShowTime;
+@synthesize graceTimer;
+@synthesize minShowTimer;
+@synthesize taskInProgress;
+@synthesize removeFromSuperViewOnHide;
+@synthesize customView;
+@synthesize showStarted;
+@synthesize mode;
+@synthesize labelText;
+@synthesize detailsLabelText;
+@synthesize progress;
+@synthesize size;
+
+#pragma mark - Class methods
+
++ (MBProgressHUD *)showHUDAddedTo:(UIView *)view animated:(BOOL)animated {
+	MBProgressHUD *hud = [[MBProgressHUD alloc] initWithView:view];
+	[view addSubview:hud];
+	[hud show:animated];
+	return MB_AUTORELEASE(hud);
+}
+
++ (BOOL)hideHUDForView:(UIView *)view animated:(BOOL)animated {
+	MBProgressHUD *hud = [MBProgressHUD HUDForView:view];
+	if (hud != nil) {
+		hud.removeFromSuperViewOnHide = YES;
+		[hud hide:animated];
+		return YES;
+	}
+	return NO;
+}
+
++ (NSUInteger)hideAllHUDsForView:(UIView *)view animated:(BOOL)animated {
+	NSArray *huds = [self allHUDsForView:view];
+	for (MBProgressHUD *hud in huds) {
+		hud.removeFromSuperViewOnHide = YES;
+		[hud hide:animated];
+	}
+	return [huds count];
+}
+
++ (MBProgressHUD *)HUDForView:(UIView *)view {
+	MBProgressHUD *hud = nil;
+	NSArray *subviews = view.subviews;
+	Class hudClass = [MBProgressHUD class];
+	for (UIView *view in subviews) {
+		if ([view isKindOfClass:hudClass]) {
+			hud = (MBProgressHUD *)view;
+		}
+	}
+	return hud;
+}
+
++ (NSArray *)allHUDsForView:(UIView *)view {
+	NSMutableArray *huds = [NSMutableArray array];
+	NSArray *subviews = view.subviews;
+	Class hudClass = [MBProgressHUD class];
+	for (UIView *view in subviews) {
+		if ([view isKindOfClass:hudClass]) {
+			[huds addObject:view];
+		}
+	}
+	return [NSArray arrayWithArray:huds];
+}
+
+#pragma mark - Lifecycle
+
+- (id)initWithFrame:(CGRect)frame {
+	self = [super initWithFrame:frame];
+	if (self) {
+		// Set default values for properties
+		self.animationType = MBProgressHUDAnimationFade;
+		self.mode = MBProgressHUDModeIndeterminate;
+		self.labelText = nil;
+		self.detailsLabelText = nil;
+		self.opacity = 0.8f;
+		self.labelFont = [UIFont boldSystemFontOfSize:kLabelFontSize];
+		self.detailsLabelFont = [UIFont boldSystemFontOfSize:kDetailsLabelFontSize];
+		self.xOffset = 0.0f;
+		self.yOffset = 0.0f;
+		self.dimBackground = NO;
+		self.margin = 20.0f;
+		self.graceTime = 0.0f;
+		self.minShowTime = 0.0f;
+		self.removeFromSuperViewOnHide = NO;
+		self.minSize = CGSizeZero;
+		self.square = NO;
+		self.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin 
+								| UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
+
+		// Transparent background
+		self.opaque = NO;
+		self.backgroundColor = [UIColor clearColor];
+		// Make it invisible for now
+		self.alpha = 0.0f;
+		
+		taskInProgress = NO;
+		rotationTransform = CGAffineTransformIdentity;
+		
+		[self setupLabels];
+		[self updateIndicators];
+		[self registerForKVO];
+		[self registerForNotifications];
+	}
+	return self;
+}
+
+- (id)initWithView:(UIView *)view {
+	NSAssert(view, @"View must not be nil.");
+	id me = [self initWithFrame:view.bounds];
+	// We need to take care of rotation ourselfs if we're adding the HUD to a window
+	if ([view isKindOfClass:[UIWindow class]]) {
+		[self setTransformForCurrentOrientation:NO];
+	}
+	return me;
+}
+
+- (id)initWithWindow:(UIWindow *)window {
+	return [self initWithView:window];
+}
+
+- (void)dealloc {
+	[self unregisterFromNotifications];
+	[self unregisterFromKVO];
+#if !__has_feature(objc_arc)
+	[indicator release];
+	[label release];
+	[detailsLabel release];
+	[labelText release];
+	[detailsLabelText release];
+	[graceTimer release];
+	[minShowTimer release];
+	[showStarted release];
+	[customView release];
+	[super dealloc];
+#endif
+}
+
+#pragma mark - Show & hide
+
+- (void)show:(BOOL)animated {
+	useAnimation = animated;
+	// If the grace time is set postpone the HUD display
+	if (self.graceTime > 0.0) {
+		self.graceTimer = [NSTimer scheduledTimerWithTimeInterval:self.graceTime target:self 
+						   selector:@selector(handleGraceTimer:) userInfo:nil repeats:NO];
+	} 
+	// ... otherwise show the HUD imediately 
+	else {
+		[self setNeedsDisplay];
+		[self showUsingAnimation:useAnimation];
+	}
+}
+
+- (void)hide:(BOOL)animated {
+	useAnimation = animated;
+	// If the minShow time is set, calculate how long the hud was shown,
+	// and pospone the hiding operation if necessary
+	if (self.minShowTime > 0.0 && showStarted) {
+		NSTimeInterval interv = [[NSDate date] timeIntervalSinceDate:showStarted];
+		if (interv < self.minShowTime) {
+			self.minShowTimer = [NSTimer scheduledTimerWithTimeInterval:(self.minShowTime - interv) target:self 
+								selector:@selector(handleMinShowTimer:) userInfo:nil repeats:NO];
+			return;
+		} 
+	}
+	// ... otherwise hide the HUD immediately
+	[self hideUsingAnimation:useAnimation];
+}
+
+- (void)hide:(BOOL)animated afterDelay:(NSTimeInterval)delay {
+	[self performSelector:@selector(hideDelayed:) withObject:[NSNumber numberWithBool:animated] afterDelay:delay];
+}
+
+- (void)hideDelayed:(NSNumber *)animated {
+	[self hide:[animated boolValue]];
+}
+
+#pragma mark - Timer callbacks
+
+- (void)handleGraceTimer:(NSTimer *)theTimer {
+	// Show the HUD only if the task is still running
+	if (taskInProgress) {
+		[self setNeedsDisplay];
+		[self showUsingAnimation:useAnimation];
+	}
+}
+
+- (void)handleMinShowTimer:(NSTimer *)theTimer {
+	[self hideUsingAnimation:useAnimation];
+}
+
+#pragma mark - Internal show & hide operations
+
+- (void)showUsingAnimation:(BOOL)animated {
+	self.alpha = 0.0f;
+	if (animated && animationType == MBProgressHUDAnimationZoom) {
+		self.transform = CGAffineTransformConcat(rotationTransform, CGAffineTransformMakeScale(1.5f, 1.5f));
+	}
+	self.showStarted = [NSDate date];
+	// Fade in
+	if (animated) {
+		[UIView beginAnimations:nil context:NULL];
+		[UIView setAnimationDuration:0.30];
+		self.alpha = 1.0f;
+		if (animationType == MBProgressHUDAnimationZoom) {
+			self.transform = rotationTransform;
+		}
+		[UIView commitAnimations];
+	}
+	else {
+		self.alpha = 1.0f;
+	}
+}
+
+- (void)hideUsingAnimation:(BOOL)animated {
+	// Fade out
+	if (animated && showStarted) {
+		[UIView beginAnimations:nil context:NULL];
+		[UIView setAnimationDuration:0.30];
+		[UIView setAnimationDelegate:self];
+		[UIView setAnimationDidStopSelector:@selector(animationFinished:finished:context:)];
+		// 0.02 prevents the hud from passing through touches during the animation the hud will get completely hidden
+		// in the done method
+		if (animationType == MBProgressHUDAnimationZoom) {
+			self.transform = CGAffineTransformConcat(rotationTransform, CGAffineTransformMakeScale(0.5f, 0.5f));
+		}
+		self.alpha = 0.02f;
+		[UIView commitAnimations];
+	}
+	else {
+		self.alpha = 0.0f;
+		[self done];
+	}
+	self.showStarted = nil;
+}
+
+- (void)animationFinished:(NSString *)animationID finished:(BOOL)finished context:(void*)context {
+	[self done];
+}
+
+- (void)done {
+	isFinished = YES;
+	self.alpha = 0.0f;
+	if ([delegate respondsToSelector:@selector(hudWasHidden:)]) {
+		[delegate performSelector:@selector(hudWasHidden:) withObject:self];
+	} 
+	if (removeFromSuperViewOnHide) {
+		[self removeFromSuperview];
+	}
+}
+
+#pragma mark - Threading
+
+- (void)showWhileExecuting:(SEL)method onTarget:(id)target withObject:(id)object animated:(BOOL)animated {
+	methodForExecution = method;
+	targetForExecution = MB_RETAIN(target);
+	objectForExecution = MB_RETAIN(object);	
+	// Launch execution in new thread
+	self.taskInProgress = YES;
+	[NSThread detachNewThreadSelector:@selector(launchExecution) toTarget:self withObject:nil];
+	// Show HUD view
+	[self show:animated];
+}
+
+- (void)launchExecution {
+	@autoreleasepool {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+		// Start executing the requested task
+		[targetForExecution performSelector:methodForExecution withObject:objectForExecution];
+#pragma clang diagnostic pop
+		// Task completed, update view in main thread (note: view operations should
+		// be done only in the main thread)
+		[self performSelectorOnMainThread:@selector(cleanUp) withObject:nil waitUntilDone:NO];
+	}
+}
+
+- (void)cleanUp {
+	taskInProgress = NO;
+	self.indicator = nil;
+#if !__has_feature(objc_arc)
+	[targetForExecution release];
+	[objectForExecution release];
+#endif
+	[self hide:useAnimation];
+}
+
+#pragma mark - UI
+
+- (void)setupLabels {
+	label = [[UILabel alloc] initWithFrame:self.bounds];
+	label.adjustsFontSizeToFitWidth = NO;
+	label.textAlignment = UITextAlignmentCenter;
+	label.opaque = NO;
+	label.backgroundColor = [UIColor clearColor];
+	label.textColor = [UIColor whiteColor];
+	label.font = self.labelFont;
+	label.text = self.labelText;
+	[self addSubview:label];
+	
+	detailsLabel = [[UILabel alloc] initWithFrame:self.bounds];
+	detailsLabel.font = self.detailsLabelFont;
+	detailsLabel.adjustsFontSizeToFitWidth = NO;
+	detailsLabel.textAlignment = UITextAlignmentCenter;
+	detailsLabel.opaque = NO;
+	detailsLabel.backgroundColor = [UIColor clearColor];
+	detailsLabel.textColor = [UIColor whiteColor];
+	detailsLabel.numberOfLines = 0;
+	detailsLabel.font = self.detailsLabelFont;
+	detailsLabel.text = self.detailsLabelText;
+	[self addSubview:detailsLabel];
+}
+
+- (void)updateIndicators {
+	
+	BOOL isActivityIndicator = [indicator isKindOfClass:[UIActivityIndicatorView class]];
+	BOOL isRoundIndicator = [indicator isKindOfClass:[MBRoundProgressView class]];
+	
+	if (mode == MBProgressHUDModeIndeterminate &&  !isActivityIndicator) {
+		// Update to indeterminate indicator
+		[indicator removeFromSuperview];
+		self.indicator = MB_AUTORELEASE([[UIActivityIndicatorView alloc]
+										 initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge]);
+		[(UIActivityIndicatorView *)indicator startAnimating];
+		[self addSubview:indicator];
+	}
+	else if (mode == MBProgressHUDModeDeterminate || mode == MBProgressHUDModeAnnularDeterminate) {
+		if (!isRoundIndicator) {
+			// Update to determinante indicator
+			[indicator removeFromSuperview];
+			self.indicator = MB_AUTORELEASE([[MBRoundProgressView alloc] init]);
+			[self addSubview:indicator];
+		}
+		if (mode == MBProgressHUDModeAnnularDeterminate) {
+			[(MBRoundProgressView *)indicator setAnnular:YES];
+		}
+	} 
+	else if (mode == MBProgressHUDModeCustomView && customView != indicator) {
+		// Update custom view indicator
+		[indicator removeFromSuperview];
+		self.indicator = customView;
+		[self addSubview:indicator];
+	} else if (mode == MBProgressHUDModeText) {
+		[indicator removeFromSuperview];
+		self.indicator = nil;
+	}
+}
+
+#pragma mark - Layout
+
+- (void)layoutSubviews {
+	
+	CGRect bounds = self.bounds;
+	
+	// Determine the total widt and height needed
+	CGFloat maxWidth = bounds.size.width - 4 * margin;
+	CGSize totalSize = CGSizeZero;
+	
+	CGRect indicatorF = indicator.bounds;
+	indicatorF.size.width = MIN(indicatorF.size.width, maxWidth);
+	totalSize.width = MAX(totalSize.width, indicatorF.size.width);
+	totalSize.height += indicatorF.size.height;
+	
+	CGSize labelSize = [label.text sizeWithFont:label.font];
+	labelSize.width = MIN(labelSize.width, maxWidth);
+	totalSize.width = MAX(totalSize.width, labelSize.width);
+	totalSize.height += labelSize.height;
+	if (labelSize.height > 0.f && indicatorF.size.height > 0.f) {
+		totalSize.height += kPadding;
+	}
+
+	CGFloat remainingHeight = bounds.size.height - totalSize.height - kPadding - 4 * margin; 
+	CGSize maxSize = CGSizeMake(maxWidth, remainingHeight);
+	CGSize detailsLabelSize = [detailsLabel.text sizeWithFont:detailsLabel.font 
+								constrainedToSize:maxSize lineBreakMode:detailsLabel.lineBreakMode];
+	totalSize.width = MAX(totalSize.width, detailsLabelSize.width);
+	totalSize.height += detailsLabelSize.height;
+	if (detailsLabelSize.height > 0.f && (indicatorF.size.height > 0.f || labelSize.height > 0.f)) {
+		totalSize.height += kPadding;
+	}
+	
+	totalSize.width += 2 * margin;
+	totalSize.height += 2 * margin;
+	
+	// Position elements
+	CGFloat yPos = roundf(((bounds.size.height - totalSize.height) / 2)) + margin + yOffset;
+	CGFloat xPos = xOffset;
+	indicatorF.origin.y = yPos;
+	indicatorF.origin.x = roundf((bounds.size.width - indicatorF.size.width) / 2) + xPos;
+	indicator.frame = indicatorF;
+	yPos += indicatorF.size.height;
+	
+	if (labelSize.height > 0.f && indicatorF.size.height > 0.f) {
+		yPos += kPadding;
+	}
+	CGRect labelF;
+	labelF.origin.y = yPos;
+	labelF.origin.x = roundf((bounds.size.width - labelSize.width) / 2) + xPos;
+	labelF.size = labelSize;
+	label.frame = labelF;
+	yPos += labelF.size.height;
+	
+	if (detailsLabelSize.height > 0.f && (indicatorF.size.height > 0.f || labelSize.height > 0.f)) {
+		yPos += kPadding;
+	}
+	CGRect detailsLabelF;
+	detailsLabelF.origin.y = yPos;
+	detailsLabelF.origin.x = roundf((bounds.size.width - detailsLabelSize.width) / 2) + xPos;
+	detailsLabelF.size = detailsLabelSize;
+	detailsLabel.frame = detailsLabelF;
+	
+	// Enforce minsize and quare rules
+	if (square) {
+		CGFloat max = MAX(totalSize.width, totalSize.height);
+		if (max <= bounds.size.width - 2 * margin) {
+			totalSize.width = max;
+		}
+		if (max <= bounds.size.height - 2 * margin) {
+			totalSize.height = max;
+		}
+	}
+	if (totalSize.width < minSize.width) {
+		totalSize.width = minSize.width;
+	} 
+	if (totalSize.height < minSize.height) {
+		totalSize.height = minSize.height;
+	}
+	
+	self.size = totalSize;
+}
+
+#pragma mark BG Drawing
+
+- (void)drawRect:(CGRect)rect {
+	
+	CGContextRef context = UIGraphicsGetCurrentContext();
+	
+	if (dimBackground) {
+		//Gradient colours
+		size_t gradLocationsNum = 2;
+		CGFloat gradLocations[2] = {0.0f, 1.0f};
+		CGFloat gradColors[8] = {0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.0f,0.75f}; 
+		CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+		CGGradientRef gradient = CGGradientCreateWithColorComponents(colorSpace, gradColors, gradLocations, gradLocationsNum);
+		CGColorSpaceRelease(colorSpace);
+		//Gradient center
+		CGPoint gradCenter= CGPointMake(self.bounds.size.width/2, self.bounds.size.height/2);
+		//Gradient radius
+		float gradRadius = MIN(self.bounds.size.width , self.bounds.size.height) ;
+		//Gradient draw
+		CGContextDrawRadialGradient (context, gradient, gradCenter,
+									 0, gradCenter, gradRadius,
+									 kCGGradientDrawsAfterEndLocation);
+		CGGradientRelease(gradient);
+	}
+	
+	// Center HUD
+	CGRect allRect = self.bounds;
+	// Draw rounded HUD bacgroud rect
+	CGRect boxRect = CGRectMake(roundf((allRect.size.width - size.width) / 2) + self.xOffset,
+								roundf((allRect.size.height - size.height) / 2) + self.yOffset, size.width, size.height);
+	float radius = 10.0f;
+	CGContextBeginPath(context);
+	CGContextSetGrayFillColor(context, 0.0f, self.opacity);
+	CGContextMoveToPoint(context, CGRectGetMinX(boxRect) + radius, CGRectGetMinY(boxRect));
+	CGContextAddArc(context, CGRectGetMaxX(boxRect) - radius, CGRectGetMinY(boxRect) + radius, radius, 3 * (float)M_PI / 2, 0, 0);
+	CGContextAddArc(context, CGRectGetMaxX(boxRect) - radius, CGRectGetMaxY(boxRect) - radius, radius, 0, (float)M_PI / 2, 0);
+	CGContextAddArc(context, CGRectGetMinX(boxRect) + radius, CGRectGetMaxY(boxRect) - radius, radius, (float)M_PI / 2, (float)M_PI, 0);
+	CGContextAddArc(context, CGRectGetMinX(boxRect) + radius, CGRectGetMinY(boxRect) + radius, radius, (float)M_PI, 3 * (float)M_PI / 2, 0);
+	CGContextClosePath(context);
+	CGContextFillPath(context);
+}
+
+#pragma mark - KVO
+
+- (void)registerForKVO {
+	for (NSString *keyPath in [self observableKeypaths]) {
+		[self addObserver:self forKeyPath:keyPath options:NSKeyValueObservingOptionNew context:NULL];
+	}
+}
+
+- (void)unregisterFromKVO {
+	for (NSString *keyPath in [self observableKeypaths]) {
+		[self removeObserver:self forKeyPath:keyPath];
+	}
+}
+
+- (NSArray *)observableKeypaths {
+	return [NSArray arrayWithObjects:@"mode", @"customView", @"labelText", @"labelFont", 
+			@"detailsLabelText", @"detailsLabelFont", @"progress", nil];
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
+	if (![NSThread isMainThread]) {
+		[self performSelectorOnMainThread:@selector(updateUIForKeypath:) withObject:keyPath waitUntilDone:NO];
+	} else {
+		[self updateUIForKeypath:keyPath];
+	}
+}
+
+- (void)updateUIForKeypath:(NSString *)keyPath {
+	if ([keyPath isEqualToString:@"mode"] || [keyPath isEqualToString:@"customView"]) {
+		[self updateIndicators];
+	} else if ([keyPath isEqualToString:@"labelText"]) {
+		label.text = self.labelText;
+	} else if ([keyPath isEqualToString:@"labelFont"]) {
+		label.font = self.labelFont;
+	} else if ([keyPath isEqualToString:@"detailsLabelText"]) {
+		detailsLabel.text = self.detailsLabelText;
+	} else if ([keyPath isEqualToString:@"detailsLabelFont"]) {
+		detailsLabel.font = self.detailsLabelFont;
+	} else if ([keyPath isEqualToString:@"progress"]) {
+		if ([indicator respondsToSelector:@selector(setProgress:)]) {
+			[(id)indicator setProgress:progress];
+		}
+		return;
+	}
+	[self setNeedsLayout];
+	[self setNeedsDisplay];
+}
+
+#pragma mark - Notifications
+
+- (void)registerForNotifications {
+	NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+	[nc addObserver:self selector:@selector(deviceOrientationDidChange:) 
+			   name:UIDeviceOrientationDidChangeNotification object:nil];
+}
+
+- (void)unregisterFromNotifications {
+	[[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)deviceOrientationDidChange:(NSNotification *)notification { 
+	UIView *superview = self.superview;
+	if (!superview) {
+		return;
+	} else if ([superview isKindOfClass:[UIWindow class]]) {
+		[self setTransformForCurrentOrientation:YES];
+	} else {
+		self.bounds = self.superview.bounds;
+		[self setNeedsDisplay];
+	}
+}
+
+- (void)setTransformForCurrentOrientation:(BOOL)animated {	
+	// Stay in sync with the superview
+	if (self.superview) {
+		self.bounds = self.superview.bounds;
+		[self setNeedsDisplay];
+	}
+	
+	UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+	float radians = 0;
+	if (UIInterfaceOrientationIsLandscape(orientation)) {
+		if (orientation == UIInterfaceOrientationLandscapeLeft) { radians = -M_PI_2; } 
+		else { radians = M_PI_2; }
+		// Window coordinates differ!
+		self.bounds = CGRectMake(0, 0, self.bounds.size.height, self.bounds.size.width);
+	} else {
+		if (orientation == UIInterfaceOrientationPortraitUpsideDown) { radians = M_PI; } 
+		else { radians = 0; }
+	}
+	rotationTransform = CGAffineTransformMakeRotation(radians);
+	
+	if (animated) {
+		[UIView beginAnimations:nil context:nil];
+	}
+	[self setTransform:rotationTransform];
+	if (animated) {
+		[UIView commitAnimations];
+	}
+}
+
+@end
+
+
+@implementation MBRoundProgressView {
+	float _progress;
+	BOOL _annular;
+}
+
+#pragma mark - Accessors
+
+- (float)progress {
+	return _progress;
+}
+
+- (void)setProgress:(float)progress {
+	_progress = progress;
+	[self setNeedsDisplay];
+}
+
+- (BOOL)isAnnular {
+	return _annular;
+}
+
+- (void)setAnnular:(BOOL)annular {
+	_annular = annular;
+	[self setNeedsDisplay];
+}
+
+#pragma mark - Lifecycle
+
+- (id)init {
+	return [self initWithFrame:CGRectMake(0.f, 0.f, 37.f, 37.f)];
+}
+
+- (id)initWithFrame:(CGRect)frame {
+	self = [super initWithFrame:frame];
+	if (self) {
+		self.backgroundColor = [UIColor clearColor];
+		self.opaque = NO;
+		_progress = 0.f;
+		_annular = NO;
+	}
+	return self;
+}
+
+#pragma mark - Drawing
+
+- (void)drawRect:(CGRect)rect {
+	
+	CGRect allRect = self.bounds;
+	CGRect circleRect = CGRectInset(allRect, 2.0f, 2.0f);
+	CGContextRef context = UIGraphicsGetCurrentContext();
+	
+	if (_annular) {
+		// Draw background
+		CGFloat lineWidth = 5.f;
+		UIBezierPath *processBackgroundPath = [UIBezierPath bezierPath];
+		processBackgroundPath.lineWidth = lineWidth;
+		processBackgroundPath.lineCapStyle = kCGLineCapRound;
+		CGPoint center = CGPointMake(self.bounds.size.width/2, self.bounds.size.height/2);
+		CGFloat radius = (self.bounds.size.width - lineWidth)/2;
+		CGFloat startAngle = - ((float)M_PI / 2); // 90 degrees
+		CGFloat endAngle = (2 * (float)M_PI) + startAngle;
+		[processBackgroundPath addArcWithCenter:center radius:radius startAngle:startAngle endAngle:endAngle clockwise:YES];
+		[[UIColor colorWithRed:1 green:1 blue:1 alpha:0.1] set];
+		[processBackgroundPath stroke];
+		// Draw progress
+		UIBezierPath *processPath = [UIBezierPath bezierPath];
+		processPath.lineCapStyle = kCGLineCapRound;
+		processPath.lineWidth = lineWidth;
+		endAngle = (self.progress * 2 * (float)M_PI) + startAngle;
+		[processPath addArcWithCenter:center radius:radius startAngle:startAngle endAngle:endAngle clockwise:YES];
+		[[UIColor whiteColor] set];
+		[processPath stroke];
+	} else {
+		// Draw background
+		CGContextSetRGBStrokeColor(context, 1.0f, 1.0f, 1.0f, 1.0f); // white
+		CGContextSetRGBFillColor(context, 1.0f, 1.0f, 1.0f, 0.1f); // translucent white
+		CGContextSetLineWidth(context, 2.0f);
+		CGContextFillEllipseInRect(context, circleRect);
+		CGContextStrokeEllipseInRect(context, circleRect);
+		// Draw progress
+		CGPoint center = CGPointMake(allRect.size.width / 2, allRect.size.height / 2);
+		CGFloat radius = (allRect.size.width - 4) / 2;
+		CGFloat startAngle = - ((float)M_PI / 2); // 90 degrees
+		CGFloat endAngle = (self.progress * 2 * (float)M_PI) + startAngle;
+		CGContextSetRGBFillColor(context, 1.0f, 1.0f, 1.0f, 1.0f); // white
+		CGContextMoveToPoint(context, center.x, center.y);
+		CGContextAddArc(context, center.x, center.y, radius, startAngle, endAngle, 0);
+		CGContextClosePath(context);
+		CGContextFillPath(context);
+	}
+}
+
+@end


### PR DESCRIPTION
- This plugin provides a simple way to use a native loading component from IOS. It does comply with the latest (future-2.x) cordova standards.
- It relies on `[MBProgressHUD](https://github.com/jdg/MBProgressHUD)` to work (MIT license, included in ./libs).
