### PR TITLE
getTwitterUsername api called added for TwitterPlugin on iOS

### DIFF
--- a/iOS/Twitter/native/ios/TwitterPlugin.h
+++ b/iOS/Twitter/native/ios/TwitterPlugin.h
@@ -25,6 +25,8 @@
 
 - (void) getPublicTimeline:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
 
+- (void) getTwitterUsername:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+
 - (void) getMentions:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
 
 - (void) performCallbackOnMainThreadforJS:(NSString*)js;

--- a/iOS/Twitter/native/ios/TwitterPlugin.m
+++ b/iOS/Twitter/native/ios/TwitterPlugin.m
@@ -93,14 +93,6 @@
                                                messageAsString:errorMessage] toErrorCallbackString:callbackId]];
     }
     else{
-        
-#if TARGET_IPHONE_SIMULATOR
-        NSString *simWarning = @"Test TwitterPlugin on Real Hardware. Tested on Cordova 1.7.0";
-        //EXC_BAD_ACCESS occurs on simulator unable to reproduce on real device
-        //running iOS 5.1 and Cordova 1.6.1
-        NSLog(@"%@",simWarning);
-#endif
-        
         [tweetViewController setCompletionHandler:^(TWTweetComposeViewControllerResult result) {
             switch (result) {
                 case TWTweetComposeViewControllerResultDone:
@@ -158,7 +150,6 @@
         if(granted) {
             NSArray *accountsArray = [accountStore accountsWithAccountType:accountType];
             ACAccount *twitterAccount = [accountsArray objectAtIndex:0];
-            NSString *userID = [[twitterAccount accountProperties] objectForKey:@"username"];
             NSString *username = twitterAccount.username;
             [super writeJavascript:[[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:username] toSuccessCallbackString:callbackId]];
         }

--- a/iOS/Twitter/native/ios/TwitterPlugin.m
+++ b/iOS/Twitter/native/ios/TwitterPlugin.m
@@ -28,10 +28,7 @@
         [tweetViewController release];
     }
 	
-	if (IsAtLeastiOSVersion(@"3.0")) {
-		NSString *version = @"5.1";
-		NSLog(@"The TwitterPlugin requires iOS %@ or above due to is dependency on Twitter.framework.", version); // @RandyMcMillan
-	}
+	
     
     [super writeJavascript:[[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:twitterSDKAvailable ? 1 : 0] toSuccessCallbackString:callbackId]];
 }
@@ -93,6 +90,14 @@
                                                messageAsString:errorMessage] toErrorCallbackString:callbackId]];
     }
     else{
+        
+#if TARGET_IPHONE_SIMULATOR
+        NSString *simWarning = @"Test TwitterPlugin on Real Hardware. Tested on Cordova 1.7.0";
+        //EXC_BAD_ACCESS occurs on simulator unable to reproduce on real device
+        //running iOS 5.1 and Cordova 1.6.1
+        NSLog(@"%@",simWarning);
+#endif
+        
         [tweetViewController setCompletionHandler:^(TWTweetComposeViewControllerResult result) {
             switch (result) {
                 case TWTweetComposeViewControllerResultDone:

--- a/iOS/Twitter/native/ios/TwitterPlugin.m
+++ b/iOS/Twitter/native/ios/TwitterPlugin.m
@@ -28,7 +28,10 @@
         [tweetViewController release];
     }
 	
-	
+	if (IsAtLeastiOSVersion(@"3.0")) {
+		NSString *version = @"5.1";
+		NSLog(@"The TwitterPlugin requires iOS %@ or above due to is dependency on Twitter.framework.", version); // @RandyMcMillan
+	}
     
     [super writeJavascript:[[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:twitterSDKAvailable ? 1 : 0] toSuccessCallbackString:callbackId]];
 }
@@ -144,6 +147,25 @@
 	}];
     
     [postRequest release];
+}
+
+- (void) getTwitterUsername:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options{
+    NSString *callbackId = [arguments objectAtIndex:0];
+    ACAccountStore *accountStore = [[ACAccountStore alloc] init];
+    ACAccountType *accountType = [accountStore accountTypeWithAccountTypeIdentifier:ACAccountTypeIdentifierTwitter];
+    
+    [accountStore requestAccessToAccountsWithType:accountType withCompletionHandler:^(BOOL granted, NSError *error) {
+        if(granted) {
+            NSArray *accountsArray = [accountStore accountsWithAccountType:accountType];
+            ACAccount *twitterAccount = [accountsArray objectAtIndex:0];
+            NSString *userID = [[twitterAccount accountProperties] objectForKey:@"username"];
+            NSString *username = twitterAccount.username;
+            [super writeJavascript:[[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:username] toSuccessCallbackString:callbackId]];
+        }
+    }];
+    
+    [accountStore release];
+
 }
 
 - (void) getMentions:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options{

--- a/iOS/Twitter/www/TwitterPlugin.js
+++ b/iOS/Twitter/www/TwitterPlugin.js
@@ -22,6 +22,10 @@ Twitter.prototype.getMentions = function(success, failure){
     cordova.exec(success, failure, "TwitterPlugin", "getMentions", []);
 };
 
+Twitter.prototype.getTwitterUsername = function(response){
+    cordova.exec(response, null, "TwitterPlugin", "getTwitterUsername", []);
+};
+
 cordova.addConstructor(function() {
 					   
 					   /* shim to work in 1.5 and 1.6  */


### PR DESCRIPTION
Hi,

Is this method of use to other people? 

Do you want to stay generic and allow the pull of any account property - or is getTwitterUsername important enough that it deserves its own call?

Comments welcome!

Mick
