### PR TITLE
getTwitterUserName switched to performCallbackOnMainThreadforJS

### DIFF
--- a/iOS/Twitter/native/ios/TwitterPlugin.m
+++ b/iOS/Twitter/native/ios/TwitterPlugin.m
@@ -156,7 +156,11 @@
             NSArray *accountsArray = [accountStore accountsWithAccountType:accountType];
             ACAccount *twitterAccount = [accountsArray objectAtIndex:0];
             NSString *username = twitterAccount.username;
-            [super writeJavascript:[[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:username] toSuccessCallbackString:callbackId]];
+            
+            NSString *jsResponse = [[CDVPluginResult resultWithStatus:CDVCommandStatus_OK 
+                                                      messageAsString:username] 
+                                    toSuccessCallbackString:callbackId];
+            [self performCallbackOnMainThreadforJS:jsResponse];
         }
     }];
     

--- a/iOS/Twitter/www/TwitterPlugin.js
+++ b/iOS/Twitter/www/TwitterPlugin.js
@@ -22,8 +22,8 @@ Twitter.prototype.getMentions = function(success, failure){
     cordova.exec(success, failure, "TwitterPlugin", "getMentions", []);
 };
 
-Twitter.prototype.getTwitterUsername = function(response){
-    cordova.exec(response, null, "TwitterPlugin", "getTwitterUsername", []);
+Twitter.prototype.getTwitterUsername = function(success, failure) {
+    cordova.exec(success, failure, "TwitterPlugin", "getTwitterUsername", []);
 };
 
 cordova.addConstructor(function() {


### PR DESCRIPTION
Changed getTwitterUserName to use the correct callback mechanism to avoid crashes
