### PR TITLE
Fix viewport for wide web pages

### DIFF
--- a/Android/ChildBrowser/src/com/phonegap/plugins/childBrowser/ChildBrowser.java
+++ b/Android/ChildBrowser/src/com/phonegap/plugins/childBrowser/ChildBrowser.java
@@ -315,6 +315,8 @@ public class ChildBrowser extends Plugin {
                 webview.setLayoutParams(wvParams);
                 webview.requestFocus();
                 webview.requestFocusFromTouch();   
+                webview.getSettings().setUseWideViewPort(true);
+                webview.getSettings().setLoadWithOverviewMode(true);
                 
                 toolbar.addView(back);
                 toolbar.addView(forward);


### PR DESCRIPTION
Adding fix from here: https://github.com/phonegap/phonegap-plugins/issues/326

Some web pages are rendered at the default zoom level and can't zoom out. This can be an issue on loading non-mobile optimized pages in ChildBrowser. This should fix the issue.
