### PR TITLE
Adding AppBlade SDK Plugin

### DIFF
--- a/iOS/AppBlade/Android/AppBlade.js
+++ b/iOS/AppBlade/Android/AppBlade.js
@@ -1,0 +1,44 @@
+/**
+ * AppBlade.js
+ *  
+ * Phonegap AppBlade Instance plugin
+ * Copyright (c) AppBlade 2012
+ *
+ */
+  
+// --------------------------------------------------------
+  
+var AppBlade = function(){};
+
+// --------------------------------------------------------
+  
+AppBlade.prototype.setupAppBlade = function(project, token, secret, timestamp) {
+    cordova.exec(null, null, "AppBlade", "setupAppBlade", [project, token, secret, timestamp]);
+};
+    
+AppBlade.prototype.catchAndReportCrashes = function() {
+	// Automatically set with Register on Android
+    //cordova.exec("AppBlade.catchAndReportCrashes");
+};
+    
+AppBlade.prototype.checkAuthentication = function() {
+	console.log("Checking authentication");
+    cordova.exec(null, null, "AppBlade", "checkAuthentication", []);
+};
+    
+AppBlade.prototype.allowFeedbackReporting = function() {
+	// Not supported yet
+    //cordova.exec("AppBlade.allowFeedbackReporting");
+};
+
+// --------------------------------------------------------
+
+cordova.addConstructor(function() {
+
+    if (!window.Cordova) {
+    window.Cordova = cordova;
+    };
+                       
+    if(!window.plugins) window.plugins = {};
+    window.plugins.appBlade = new AppBlade();
+});

--- a/iOS/AppBlade/Android/AppBladePlugin.java
+++ b/iOS/AppBlade/Android/AppBladePlugin.java
@@ -1,0 +1,57 @@
+/**
+ * 
+ */
+package com.phonegap.helloworld;
+
+import org.apache.cordova.api.PluginResult;
+import org.json.JSONArray;
+
+import android.util.Log;
+
+import com.phonegap.api.Plugin;
+
+import android.app.Activity;
+
+import com.appblade.framework.AppBlade;
+
+/**
+ * @author micheletitolo
+ *
+ */
+public class AppBladePlugin extends Plugin {
+	public static final String SETUP="setupAppBlade";
+	public static final String CHECKAPPROVAL="checkAuthentication";
+	/* (non-Javadoc)
+	 * @see org.apache.cordova.api.Plugin#execute(java.lang.String, org.json.JSONArray, java.lang.String)
+	 */
+	@Override
+	public PluginResult execute(String action, JSONArray data, String callbackId) {
+		PluginResult result = null;
+		if (SETUP.equals(action)) {
+			String token = data.optString(2);
+			String secret = data.optString(1);
+			String uuid = data.optString(0);
+			String issuance = data.optString(3);
+			
+			AppBlade.register(this.ctx.getApplicationContext(), token, secret, uuid, issuance);
+			result = new PluginResult(PluginResult.Status.OK);
+		}
+		else if (CHECKAPPROVAL.equals(action))
+		{
+	        // PhoneGap runs on its own thread. So we need one to display an alert and do our UI on.
+	        this.ctx.runOnUiThread(new Runnable() {
+	            
+	            public void run() {
+	                AppBlade.authorize((Activity) AppBladePlugin.this.ctx);
+	            }
+	        });
+			result = new PluginResult(PluginResult.Status.OK);
+		}
+		else {
+			result = new PluginResult(PluginResult.Status.INVALID_ACTION);
+		}
+		
+		return result;
+	}
+
+}

--- a/iOS/AppBlade/README.md
+++ b/iOS/AppBlade/README.md
@@ -1,0 +1,33 @@
+AppBladeSDK PhoneGap Plugin
+===================
+
+Plugin for PhoneGap that uses the AppBlade SDK.
+
+###Organization
+For each operating system currently supported by the SDK there is a folder which contains a `/Plugin` folder that contains the plugin, and `/Example` folder which contains a sample project to get you started.
+
+##Installation - iOS
+
+1. Copy `AppBlade.js` from into your `www` directory.
+2. Copy `AppBladePlugin.[hm]` into your Plugins folder.
+3. Follow directions for [adding plugins to your iOS project](http://wiki.phonegap.com/w/page/43708792/How%20to%20Install%20a%20PhoneGap%20Plugin%20for%20iOS).
+3. Follow directions for [adding the AppBlade SDK to your project](http://github.com/AppBlade/SDK), but do not edit the `AppDelegate`.
+4. Add `-all_load` to the `other linker flags` build setting for your target.
+5. In your `index.html`, register for the `"deviceready"` eventListener, and call the setup method with your SDK keys in this order: project, token, secret, issued timestamp.
+
+See the Example project included for examples using the other functions of the SDK.
+
+##Installation - Android
+
+1. Copy `AppBlade.js` into your `www` directory.
+2. Add `AppBladePlugin.java` to your project.
+3. Follow directions for [adding plugins to your Android project](http://wiki.phonegap.com/w/page/43708611/How%20to%20Install%20a%20PhoneGap%20Plugin%20for%20Android).
+3. Follow directions for [adding the AppBlade SDK to your project](http://github.com/AppBlade/SDK), but do not do the last 2 steps where you edit your main activity file.
+3. In your `index.html`, register for the `"deviceready"` eventListener, and call the setup method with your SDK keys in this order: project, token, secret, issued timestamp.
+
+See the Example project included for examples using the other functions of the SDK.
+
+
+##Resources:
+###[AppBlade.com](https://appblade.com/)
+###[License and Terms](https://appblade.com/terms_of_use)

--- a/iOS/AppBlade/iOS/AppBlade.js
+++ b/iOS/AppBlade/iOS/AppBlade.js
@@ -1,0 +1,40 @@
+/**
+ * AppBlade.js
+ *  
+ * Phonegap AppBlade Instance plugin
+ * Copyright (c) AppBlade 2012
+ *
+ */
+  
+// --------------------------------------------------------
+  
+var AppBlade = function(){};
+
+// --------------------------------------------------------
+  
+AppBlade.prototype.setupAppBlade = function(project, token, secret, timestamp) {
+    cordova.exec("AppBlade.setupAppBlade", [project, token, secret, timestamp]);
+};
+    
+AppBlade.prototype.catchAndReportCrashes = function() {
+    cordova.exec("AppBlade.catchAndReportCrashes");
+};
+    
+AppBlade.prototype.checkAuthentication = function() {
+    cordova.exec("AppBlade.checkAuthentication");
+};
+    
+AppBlade.prototype.allowFeedbackReporting = function() {
+    cordova.exec("AppBlade.allowFeedbackReporting");
+};
+
+// --------------------------------------------------------
+
+cordova.addConstructor(function() {
+    if (!window.Cordova) {
+    window.Cordova = cordova;
+    };
+                       
+    if(!window.plugins) window.plugins = {};
+    window.plugins.appBlade = new AppBlade();
+});

--- a/iOS/AppBlade/iOS/AppBladePlugin.h
+++ b/iOS/AppBlade/iOS/AppBladePlugin.h
@@ -1,0 +1,19 @@
+//
+//  AppBladePlugin.h
+//  HelloWorld
+//
+//  Created by Michele Titolo on 5/14/12.
+//  Copyright (c) 2012 AppBlade. All rights reserved.
+//
+
+#import <Cordova/CDVPlugin.h>
+
+@interface AppBladePlugin : CDVPlugin
+
+- (void)setupAppBlade:(NSMutableArray*)args withDict:(NSMutableDictionary*)options;
+
+- (void)catchAndReportCrashes:(NSMutableArray*)args withDict:(NSMutableDictionary*)options;
+- (void)allowFeedbackReporting:(NSMutableArray*)args withDict:(NSMutableDictionary*)options;
+- (void)checkAuthentication:(NSMutableArray*)args withDict:(NSMutableDictionary*)options;
+
+@end

--- a/iOS/AppBlade/iOS/AppBladePlugin.m
+++ b/iOS/AppBlade/iOS/AppBladePlugin.m
@@ -1,0 +1,55 @@
+//
+//  AppBladePlugin.m
+//  HelloWorld
+//
+//  Created by Michele Titolo on 5/14/12.
+//  Copyright (c) 2012 AppBlade. All rights reserved.
+//
+
+#import "AppBladePlugin.h"
+#import "AppBlade.h"
+
+enum {
+    ABProjectID = 0,
+    ABToken,
+    ABSecretKey,
+    ABTimestamp
+};
+
+@implementation AppBladePlugin
+
+- (void)setupAppBlade:(NSMutableArray*)args withDict:(NSMutableDictionary*)options
+{
+    NSArray* keys = [args objectAtIndex:0];
+    NSLog(@"Setup with stuff: %@", keys);
+    NSString* project = [keys objectAtIndex:ABProjectID];
+    NSString* token = [keys objectAtIndex:ABToken];
+    NSString* secret = [keys objectAtIndex:ABSecretKey];
+    NSString* timestamp = [keys objectAtIndex:ABTimestamp];
+    
+    AppBlade *blade = [AppBlade sharedManager];
+    blade.appBladeProjectID = project;
+    blade.appBladeProjectToken = token;
+    blade.appBladeProjectSecret = secret;
+    blade.appBladeProjectIssuedTimestamp = timestamp;
+}
+
+- (void)catchAndReportCrashes:(NSMutableArray *)args withDict:(NSMutableDictionary *)options
+{
+    NSLog(@"Catch and Report Crashes");
+    [[AppBlade sharedManager] catchAndReportCrashes];
+}
+
+- (void)checkAuthentication:(NSMutableArray *)args withDict:(NSMutableDictionary *)options
+{
+    NSLog(@"Check approval");
+    [[AppBlade sharedManager] checkApproval];
+}
+
+- (void)allowFeedbackReporting:(NSMutableArray *)args withDict:(NSMutableDictionary *)options
+{
+    NSLog(@"Allow Feedback");
+    [[AppBlade sharedManager] allowFeedbackReporting];
+}
+
+@end


### PR DESCRIPTION
Created a plugin that makes use of the AppBlade SDK for easier beta testing and enterprise deployment. Currently only supports iOS and Android. Compatible with Cordova 1.6+.
