### PR TITLE
Updated Android Share plugin for Cordova 1.6+

### DIFF
--- a/Android/Share/README.md
+++ b/Android/Share/README.md
@@ -26,6 +26,9 @@ window.plugins.share.show({
 
 ## Release notes
 
+### 5/29/2012
+* Updated for Cordova 1.6+ by @devgeeks
+
 ### 8/22/2011
 * Updated for PhoneGap 1.0
 

--- a/Android/Share/Share.java
+++ b/Android/Share/Share.java
@@ -13,8 +13,8 @@ import org.json.JSONObject;
 
 import android.content.Intent;
 
-import com.phonegap.api.Plugin;
-import com.phonegap.api.PluginResult;
+import org.apache.cordova.api.Plugin;
+import org.apache.cordova.api.PluginResult;
 
 public class Share extends Plugin {
 

--- a/Android/Share/share.js
+++ b/Android/Share/share.js
@@ -6,20 +6,15 @@
  */
 
 var Share = function() {};
-			
+            
 Share.prototype.show = function(content, success, fail) {
-	return PhoneGap.exec( function(args) {
-		success(args);
-	}, function(args) {
-		fail(args);
-	}, 'Share', '', [content]);
+    return cordova.exec( function(args) {
+        success(args);
+    }, function(args) {
+        fail(args);
+    }, 'Share', '', [content]);
 };
 
-PhoneGap.addConstructor(function() {
-	/**
-	 * Phonegap version < 1.0
-	 * use the following line
-	 */
-	// PhoneGap.addPlugin('share', new Share());
-	PluginManager.addService("Share","com.schaul.plugins.share.Share");
+cordova.addConstructor(function(){
+    cordova.addPlugin('share', new Share());
 });


### PR DESCRIPTION
I don't want to merge my own pull request, especially since I don't know what we are doing regarding Cordova updates to Android plugins.

This plugin is super useful but hadn't been updated in nearly a year... someone needed it in IRC so I quickly fixed it up.

If we are just updating the Android ones in place (as opposed to how we are separating the iOS ones) then go ahead and merge this puppy... otherwise just tell me how and I will close it and re-do it.
