### PR TITLE
Updated ShareKitPlugin to Cordova 1.7 / ShareKit 2.0

### DIFF
--- a/iOS/ShareKitPlugin/README.md
+++ b/iOS/ShareKitPlugin/README.md
@@ -9,25 +9,25 @@ Updated for Cordova 1.7/Sharekit 2.0 by Kerri Shotts
 
 * Download [ShareKit 2.0](https://github.com/ShareKit/ShareKit) and install it into your project following the instructions provided in [the wiki](https://github.com/ShareKit/ShareKit/wiki).
 
-** Make sure you follow *all* the steps, all the way through step 7. This will ensure you have FaceBook SSO working properly.
+* * Make sure you follow *all* the steps, all the way through step 7. This will ensure you have FaceBook SSO working properly.
 
-** Also make sure to configure the services with their appropriate API keys. This step is not described particularly well on the wiki. It boils down to creating a new Objective C class in your project that is based on DefaultSHKConfigurator, copying & pasting from DefaultSHKConfigurator, and filling in your API keys. (See the example configuration files under example-config directory.)
+* * Also make sure to configure the services with their appropriate API keys. This step is not described particularly well on the wiki. It boils down to creating a new Objective C class in your project that is based on DefaultSHKConfigurator, copying & pasting from DefaultSHKConfigurator, and filling in your API keys. (See the example configuration files under example-config directory.)
 
 * Because ShareKit utilizes JSONKit, you will receive errors when building your app. You *must*:
 
-** Update the subproject's User Header Search Paths for the Sharekit SubProject to "/Users/Shared/Cordova/Frameworks/Cordova.framework/**"
+* * Update the subproject's User Header Search Paths for the Sharekit SubProject to "/Users/Shared/Cordova/Frameworks/Cordova.framework/**"
 
-** Rename (or delete) Sharekit's JSONKit.h/.m. If you rename them, make sure not to have an ending in .h or .m.
+* * Rename (or delete) Sharekit's JSONKit.h/.m. If you rename them, make sure not to have an ending in .h or .m.
 
 ### Other potential issues you may (or may not) have:
 
 * Instant crash due to missing symbol _NSURLIsExcludedFromBackupKey on IOS < 5.1
 
-** Current fix: comment lines 804-814 out in SHK.m. If anyone has a better fix, I'd love to hear it.
+* * Current fix: comment lines 804-814 out in SHK.m. If anyone has a better fix, I'd love to hear it.
 
 * Crashes when trying to share from the action sheet OR when cancelling an action.
 
-** In hideCurrentViewControllerAnimated, comment out the completion block and change the method to dismissModalViewControllerAnimated. It should look like this:
+* * In hideCurrentViewControllerAnimated, comment out the completion block and change the method to dismissModalViewControllerAnimated. It should look like this:
 
     [[currentView presentingViewController] dismissModalViewControllerAnimated:animated ];
     /* completion:^{                                                                           
@@ -36,7 +36,7 @@ Updated for Cordova 1.7/Sharekit 2.0 by Kerri Shotts
          }];
       }];*/
 
-** Crash when sharing with Twitter on iOS 5 - the simple fix is to force the old Twitter method used in iOS 4 and below in your configuration file. 
+* * Crash when sharing with Twitter on iOS 5 - the simple fix is to force the old Twitter method used in iOS 4 and below in your configuration file. 
 
 ## Adding the Plugin to the Project
 

--- a/iOS/ShareKitPlugin/README.md
+++ b/iOS/ShareKitPlugin/README.md
@@ -8,18 +8,25 @@ Updated for Cordova 1.7/Sharekit 2.0 by Kerri Shotts
 ## Adding ShareKit to a PhoneGap Project (revised for 2.0)
 
 * Download [ShareKit 2.0](https://github.com/ShareKit/ShareKit) and install it into your project following the instructions provided in [the wiki](https://github.com/ShareKit/ShareKit/wiki).
+
 ** Make sure you follow *all* the steps, all the way through step 7. This will ensure you have FaceBook SSO working properly.
+
 ** Also make sure to configure the services with their appropriate API keys. This step is not described particularly well on the wiki. It boils down to creating a new Objective C class in your project that is based on DefaultSHKConfigurator, copying & pasting from DefaultSHKConfigurator, and filling in your API keys. (See the example configuration files under example-config directory.)
+
 * Because ShareKit utilizes JSONKit, you will receive errors when building your app. You *must*:
+
 ** Update the subproject's User Header Search Paths for the Sharekit SubProject to "/Users/Shared/Cordova/Frameworks/Cordova.framework/**"
+
 ** Rename (or delete) Sharekit's JSONKit.h/.m. If you rename them, make sure not to have an ending in .h or .m.
 
 ### Other potential issues you may (or may not) have:
 
 * Instant crash due to missing symbol _NSURLIsExcludedFromBackupKey on IOS < 5.1
+
 ** Current fix: comment lines 804-814 out in SHK.m. If anyone has a better fix, I'd love to hear it.
 
 * Crashes when trying to share from the action sheet OR when cancelling an action.
+
 ** In hideCurrentViewControllerAnimated, comment out the completion block and change the method to dismissModalViewControllerAnimated. It should look like this:
 
     [[currentView presentingViewController] dismissModalViewControllerAnimated:animated ];
@@ -76,6 +83,7 @@ you must logout the current one first );
 9. `shareToMail(subject, body)` Opens up the iOS mail dialog with pre-filled subject and body
 
 ## Running the example
+
 The example has been removed; I don't have the time to upgrade it with all the various issues involved in moving it to Sharekit 2.0. The plugin /does/ work; however you should use the above as a reference.
 
 ## Limitations

--- a/iOS/ShareKitPlugin/README.md
+++ b/iOS/ShareKitPlugin/README.md
@@ -1,0 +1,112 @@
+#ShareKit plugin for Phonegap 
+
+By Erick Camacho
+Updated for Cordova 1.7/Sharekit 2.0 by Kerri Shotts
+
+> (KS 05/30/2012) **IMPORTANT** This update was done with Sharekit 2.0 in place (as obtained from https://github.com/ShareKit/ShareKit). The previous version at http://getsharekit.com proved too unstable and had major bugs under iOS 5. That said, it may still work, but I can't gaurantee it. 
+
+## Adding ShareKit to a PhoneGap Project (revised for 2.0)
+
+* Download [ShareKit 2.0](https://github.com/ShareKit/ShareKit) and install it into your project following the instructions provided in [the wiki](https://github.com/ShareKit/ShareKit/wiki).
+** Make sure you follow *all* the steps, all the way through step 7. This will ensure you have FaceBook SSO working properly.
+** Also make sure to configure the services with their appropriate API keys. This step is not described particularly well on the wiki. It boils down to creating a new Objective C class in your project that is based on DefaultSHKConfigurator, copying & pasting from DefaultSHKConfigurator, and filling in your API keys. (See the example configuration files under example-config directory.)
+* Because ShareKit utilizes JSONKit, you will receive errors when building your app. You *must*:
+** Update the subproject's User Header Search Paths for the Sharekit SubProject to "/Users/Shared/Cordova/Frameworks/Cordova.framework/**"
+** Rename (or delete) Sharekit's JSONKit.h/.m. If you rename them, make sure not to have an ending in .h or .m.
+
+### Other potential issues you may (or may not) have:
+
+* Instant crash due to missing symbol _NSURLIsExcludedFromBackupKey on IOS < 5.1
+** Current fix: comment lines 804-814 out in SHK.m. If anyone has a better fix, I'd love to hear it.
+
+* Crashes when trying to share from the action sheet OR when cancelling an action.
+** In hideCurrentViewControllerAnimated, comment out the completion block and change the method to dismissModalViewControllerAnimated. It should look like this:
+
+    [[currentView presentingViewController] dismissModalViewControllerAnimated:animated ];
+    /* completion:^{                                                                           
+        [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+           [[NSNotificationCenter defaultCenter] postNotificationName:SHKHideCurrentViewFinishedNotification object:nil];
+         }];
+      }];*/
+
+** Crash when sharing with Twitter on iOS 5 - the simple fix is to force the old Twitter method used in iOS 4 and below in your configuration file. 
+
+## Adding the Plugin to the Project
+
+1. Copy ShareKitPlugin.h, ShareKitPlugin.m, SHKSharer+Phonegap.h and SHKSharer+Phonegap.m to your project. 
+2. Add both files to the Plugins Folder in Xcode.
+3. Copy the ShareKitPlugin.js to your www folder.
+4. Modify the PhoneGap.plist file of your application. Under the key "Plugins" add another one with key name
+ShareKitPlugin and value ShareKitPlugin.
+
+
+## Using the plugin
+
+
+Add the js file to your html. 
+
+The plugin registers itself in the variable window.plugins.shareKit. It exposes the following methods:
+
+1. `share( message, url )` Displays the ShareKit Form to share the given message and URL on a social network.
+
+2. `isLoggedToTwitter( callback )` Returns wheter the user is logged in to twitter or no. Invokes the callback with an int argument :
+
+	window.plugins.shareKit.isLoggedToTwitter( function( isLogged ) {
+		if( isLogged ) {
+			//do something
+		} else {
+			//do something
+		}
+	});
+
+3. `isLoggedToFacebook( callback )` Returns wheter the user is logged in to Facebook or no. Invokes the callback with an int argument.
+
+4. `logoutFromTwitter( )` Logouts the user from Twitter (By default, ShareKit keeps the user logged in. So if you want to log in with a different user
+you must logout the current one first );
+
+5. `logoutFromFacebook( )` Logouts the user from Facebook (By default, ShareKit keeps the user logged in. So if you want to log in with a different user
+you must logout the current one first );
+
+6. `facebookConnect( )` Shows the Facebook Login form, if the user is not logged in. Convenient method for login to Facebook without showing the post in the wall form.
+
+7. `shareToFacebook(message, url )` Shows only the post in the wall form of Facebook if the user is logged in. 
+
+8. `shareToTwitter(message, url)` Shares an item specifically with Twitter, will automatically shorten the URL
+
+9. `shareToMail(subject, body)` Opens up the iOS mail dialog with pre-filled subject and body
+
+## Running the example
+The example has been removed; I don't have the time to upgrade it with all the various issues involved in moving it to Sharekit 2.0. The plugin /does/ work; however you should use the above as a reference.
+
+## Limitations
+
+Currently the plugin can only share messages and URLs. In the future I will add functionality to share images as well.
+
+Because in my current project I'm only sharing content to Twitter and Facebook, I've only added methods to logout from this two social networks. You can easily add methods to logout from other networks following these examples.
+
+## License 
+
+
+The MIT License
+
+Copyright (c) 2011 Erick Camacho
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+

--- a/iOS/ShareKitPlugin/SHKSharer+Phonegap.h
+++ b/iOS/ShareKitPlugin/SHKSharer+Phonegap.h
@@ -1,0 +1,16 @@
+//
+//  SHKSharer+Phonegap.h
+//  example
+//
+//  Created by Erick Camacho Chavarría on 13/08/11.
+//  Copyright 2011 __MyCompanyName__. All rights reserved.
+//
+
+#import "SHKSharer.h"
+
+@interface SHKSharer (SHKSharer_Phonegap)
+
+//Shows only the login form of the service without showing the share form
++ (id)loginToService;
+
+@end

--- a/iOS/ShareKitPlugin/SHKSharer+Phonegap.m
+++ b/iOS/ShareKitPlugin/SHKSharer+Phonegap.m
@@ -1,0 +1,23 @@
+//
+//  SHKSharer+Phonegap.m
+//  example
+//
+//  Created by Erick Camacho Chavarría on 13/08/11.
+//  Copyright 2011 __MyCompanyName__. All rights reserved.
+//
+
+#import "SHKSharer+Phonegap.h"
+
+@implementation SHKSharer (SHKSharer_Phonegap)
+
++ (id)loginToService {
+    
+    SHKSharer *controller = [[self alloc] init];
+    if( ![controller isAuthorized] ) {
+        [controller promptAuthorization];
+    }
+    
+    return [controller autorelease];
+}
+
+@end

--- a/iOS/ShareKitPlugin/ShareKitPlugin.h
+++ b/iOS/ShareKitPlugin/ShareKitPlugin.h
@@ -1,0 +1,50 @@
+//
+//  ShareKitPlugin.h
+//  
+//
+//  Created by Erick Camacho on 28/07/11.
+//  MIT Licensed
+//
+
+#import <Foundation/Foundation.h>
+
+#import "SHK.h"
+#import "SHKSharer+Phonegap.h"
+#ifdef CORDOVA_FRAMEWORK
+#import <Cordova/CDVPlugin.h>
+#import <Cordova/CDVPluginResult.h>
+//#import <Cordova/JSONKit.h>
+
+#else
+#import "CDVPlugin.h"
+#import "CDVPluginResult.h"
+//#import "JSONKit.h"
+#endif
+
+
+
+@interface ShareKitPlugin : CDVPlugin {
+
+    
+}
+
+
+- (void)share:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+
+- (void)isLoggedToTwitter:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+
+- (void)isLoggedToFacebook:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+
+- (void)logoutFromTwitter:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+
+- (void)logoutFromFacebook:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+
+- (void)facebookConnect:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+
+- (void)shareToFacebook:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+
+- (void)shareToTwitter:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+
+- (void)shareToMail:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+
+@end

--- a/iOS/ShareKitPlugin/ShareKitPlugin.js
+++ b/iOS/ShareKitPlugin/ShareKitPlugin.js
@@ -1,0 +1,91 @@
+//
+//  ShareKitPlugin.js
+//  
+//
+//  Created by Erick Camacho on 28/07/11.
+//  MIT Licensed
+//
+
+function ShareKitPlugin()
+{
+	console.log('creating plugin');
+};
+
+ShareKitPlugin.prototype.share = function(message, url)
+{
+	cordova.exec(null, null, "ShareKitPlugin", "share", [message, url]);
+    
+};
+
+
+ShareKitPlugin.prototype.isLoggedToTwitter = function( callback )
+{
+	
+    cordova.exec(callback, null, "ShareKitPlugin", "isLoggedToTwitter", [] );
+};
+
+ShareKitPlugin.prototype.isLoggedToFacebook = function( callback )
+{
+	
+    cordova.exec(callback, null, "ShareKitPlugin", "isLoggedToFacebook", [] );
+
+};
+
+ShareKitPlugin.prototype.logoutFromTwitter = function()
+{
+	
+    cordova.exec(null, null, "ShareKitPlugin", "logoutFromTwitter", [] );
+
+};
+
+ShareKitPlugin.prototype.logoutFromFacebook = function()
+{
+	
+    cordova.exec(null, null, "ShareKitPlugin", "logoutFromFacebook", [] );
+
+};
+
+
+ShareKitPlugin.prototype.facebookConnect = function()
+{
+	
+    cordova.exec(null, null, "ShareKitPlugin", "facebookConnect", [] );
+    
+};
+
+ShareKitPlugin.prototype.shareToFacebook = function( message, url)
+{
+	
+    cordova.exec(null, null, "ShareKitPlugin", "shareToFacebook", [message, url] );
+    
+};
+
+ShareKitPlugin.prototype.shareToTwitter = function( message, url)
+{
+	
+    cordova.exec(null, null, "ShareKitPlugin", "shareToTwitter", [message, url] );
+    
+};
+
+ShareKitPlugin.prototype.shareToMail = function( subject, message)
+{
+	
+    cordova.exec(null, null, "ShareKitPlugin", "shareToMail", [subject, message] );
+    
+};
+
+
+
+
+ShareKitPlugin.install = function()
+{
+    if(!window.plugins)
+    {
+        window.plugins = {};	
+    }
+
+    window.plugins.shareKit = new ShareKitPlugin();
+    return window.plugins.shareKit;
+};
+
+cordova.addConstructor(ShareKitPlugin.install);

--- a/iOS/ShareKitPlugin/ShareKitPlugin.m
+++ b/iOS/ShareKitPlugin/ShareKitPlugin.m
@@ -1,0 +1,127 @@
+//
+//  ShareKitPlugin.m
+//
+//  Created by Erick Camacho on 28/07/11.
+//  MIT Licensed
+//
+
+#import "ShareKitPlugin.h"
+
+#import "SHKTwitter.h"
+#import "SHKFacebook.h"
+#import "SHKMail.h"
+
+
+@interface ShareKitPlugin (PrivateMethods)
+
+- (void)IsLoggedToService:(BOOL)isLogged callback:(NSString *) callback;
+
+@end
+
+@implementation ShareKitPlugin
+
+
+- (void) share:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options { 
+    
+    NSString *message = [arguments objectAtIndex:1];
+    SHKItem *item;
+    if ([arguments objectAtIndex:2]==NULL) {
+        NSURL *itemUrl = [NSURL URLWithString:[arguments objectAtIndex:2]];  
+        item = [SHKItem URL:itemUrl title:message contentType:SHKURLContentTypeWebpage];
+    } else {
+        item = [SHKItem text:message];
+    }
+        
+	SHKActionSheet *actionSheet = [SHKActionSheet actionSheetForItem:item];
+    [SHK setRootViewController:self.viewController];
+
+	[actionSheet showInView:self.viewController.view];
+}
+
+- (void)isLoggedToTwitter:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options {
+    NSString *callback = [arguments objectAtIndex:0];   
+    [self IsLoggedToService:[SHKTwitter isServiceAuthorized] callback:callback];
+}
+
+- (void)isLoggedToFacebook:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options {
+    
+    NSString *callback = [arguments objectAtIndex:0];   
+    [self IsLoggedToService:[SHKFacebook isServiceAuthorized] callback:callback];
+}
+
+- (void)IsLoggedToService:(BOOL)isLogged callback:(NSString *) callback {
+    
+    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus: CDVCommandStatus_OK messageAsInt: isLogged ];
+    [self writeJavascript:[pluginResult toSuccessCallbackString:callback]];    
+}
+
+
+- (void)logoutFromTwitter:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options {    
+    [SHKTwitter logout];
+}
+
+- (void)logoutFromFacebook:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options {
+   
+    [SHKFacebook logout];
+}
+
+- (void)facebookConnect:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options {
+    if (![SHKFacebook isServiceAuthorized]) {
+    [SHK setRootViewController:self.viewController];
+        [SHKFacebook loginToService];
+    }
+}
+
+- (void)shareToFacebook:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options {
+        
+    [SHK setRootViewController:self.viewController];
+    
+    SHKItem *item;
+    
+    NSString *message = [arguments objectAtIndex:1];
+    if ([arguments objectAtIndex:2]==NULL) {
+        NSURL *itemUrl = [NSURL URLWithString:[arguments objectAtIndex:2]];  
+        item = [SHKItem URL:itemUrl title:message contentType:SHKURLContentTypeWebpage];
+    } else {
+        item = [SHKItem text:message];
+    }
+    
+    [SHKFacebook shareItem:item];
+    
+}
+
+- (void)shareToTwitter:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options {
+    [SHK setRootViewController:self.viewController];
+    
+    SHKItem *item;
+    
+    NSString *message = [arguments objectAtIndex:1];
+    if ([arguments objectAtIndex:2]==NULL) {
+        NSURL *itemUrl = [NSURL URLWithString:[arguments objectAtIndex:2]];  
+        item = [SHKItem URL:itemUrl title:message contentType:SHKURLContentTypeWebpage];
+    } else {
+        item = [SHKItem text:message];
+    }
+    
+    [SHKTwitter shareItem:item];
+
+}
+
+- (void)shareToMail:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options {
+    [SHK setRootViewController:self.viewController];
+    
+    SHKItem *item;
+    
+    NSString *message = [arguments objectAtIndex:1];
+    if ([arguments objectAtIndex:2]==NULL) {
+        NSURL *itemUrl = [NSURL URLWithString:[arguments objectAtIndex:2]];  
+        item = [SHKItem URL:itemUrl title:message contentType:SHKURLContentTypeWebpage];
+    } else {
+        item = [SHKItem text:message];
+    }
+    
+    [SHKMail shareItem:item];
+    
+}
+
+@end

--- a/iOS/ShareKitPlugin/example-config/AppDelegate.m
+++ b/iOS/ShareKitPlugin/example-config/AppDelegate.m
@@ -1,0 +1,148 @@
+
+//
+//  AppDelegate.m
+//  Socializer
+//
+//  Created by Kerri Shotts on 5/22/12.
+//
+
+#import "AppDelegate.h"
+#import "MainViewController.h"
+#import "SHK.h"
+#import "SHKConfiguration.h"
+#import "MySHKConfiguration.h"
+#import "SHKFacebook.h"
+
+#ifdef CORDOVA_FRAMEWORK
+    #import <Cordova/CDVPlugin.h>
+    #import <Cordova/CDVURLProtocol.h>
+#else
+    #import "CDVPlugin.h"
+    #import "CDVURLProtocol.h"
+#endif
+
+
+@implementation AppDelegate
+
+@synthesize window, viewController;
+
+- (id) init
+{	
+	/** If you need to do any extra app-specific initialization, you can do it here
+	 *  -jm
+	 **/
+    NSHTTPCookieStorage *cookieStorage = [NSHTTPCookieStorage sharedHTTPCookieStorage]; 
+    [cookieStorage setCookieAcceptPolicy:NSHTTPCookieAcceptPolicyAlways];
+        
+    [CDVURLProtocol registerURLProtocol];
+    
+    return [super init];
+}
+
+#pragma UIApplicationDelegate implementation
+
+/**
+ * This is main kick off after the app inits, the views and Settings are setup here. (preferred - iOS4 and up)
+ */
+- (BOOL) application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions
+{    
+    NSURL* url = [launchOptions objectForKey:UIApplicationLaunchOptionsURLKey];
+    NSString* invokeString = nil;
+    
+    if (url && [url isKindOfClass:[NSURL class]]) {
+        invokeString = [url absoluteString];
+		NSLog(@"Socializer launchOptions = %@", url);
+    }    
+    
+    CGRect screenBounds = [[UIScreen mainScreen] bounds];
+    self.window = [[[UIWindow alloc] initWithFrame:screenBounds] autorelease];
+    self.window.autoresizesSubviews = YES;
+    
+    CGRect viewBounds = [[UIScreen mainScreen] applicationFrame];
+    
+    self.viewController = [[[MainViewController alloc] init] autorelease];
+    self.viewController.useSplashScreen = YES;
+    self.viewController.wwwFolderName = @"www";
+    self.viewController.startPage = @"index.html";
+    self.viewController.invokeString = invokeString;
+    self.viewController.view.frame = viewBounds;
+    
+    // check whether the current orientation is supported: if it is, keep it, rather than forcing a rotation
+    BOOL forceStartupRotation = YES;
+    UIDeviceOrientation curDevOrientation = [[UIDevice currentDevice] orientation];
+    
+    if (UIDeviceOrientationUnknown == curDevOrientation) {
+        // UIDevice isn't firing orientation notifications yet… go look at the status bar
+        curDevOrientation = (UIDeviceOrientation)[[UIApplication sharedApplication] statusBarOrientation];
+    }
+    
+    if (UIDeviceOrientationIsValidInterfaceOrientation(curDevOrientation)) {
+        for (NSNumber *orient in self.viewController.supportedOrientations) {
+            if ([orient intValue] == curDevOrientation) {
+                forceStartupRotation = NO;
+                break;
+            }
+        }
+    } 
+    
+    if (forceStartupRotation) {
+        NSLog(@"supportedOrientations: %@", self.viewController.supportedOrientations);
+        // The first item in the supportedOrientations array is the start orientation (guaranteed to be at least Portrait)
+        UIInterfaceOrientation newOrient = [[self.viewController.supportedOrientations objectAtIndex:0] intValue];
+        NSLog(@"AppDelegate forcing status bar to: %d from: %d", newOrient, curDevOrientation);
+        [[UIApplication sharedApplication] setStatusBarOrientation:newOrient];
+    }
+    
+    [self.window addSubview:self.viewController.view];
+    [self.window makeKeyAndVisible];
+
+    // support sharekit
+    DefaultSHKConfigurator *configurator = [[MySHKConfiguration alloc] init];
+    [SHKConfiguration sharedInstanceWithConfigurator:configurator];
+    
+    [SHK flushOfflineQueue];
+    
+    return YES;
+}
+
+// this happens while we are running ( in the background, or from within our own app )
+// only valid if Socializer-Info.plist specifies a protocol to handle
+- (BOOL) application:(UIApplication*)application handleOpenURL:(NSURL*)url 
+{
+    if (!url) { 
+        return NO; 
+    }
+    
+	// calls into javascript global function 'handleOpenURL'
+    NSString* jsString = [NSString stringWithFormat:@"handleOpenURL(\"%@\");", url];
+    [self.viewController.webView stringByEvaluatingJavaScriptFromString:jsString];
+    
+    // all plugins will get the notification, and their handlers will be called 
+    [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginHandleOpenURLNotification object:url]];
+    
+    return [self handleOpenURL:url];  
+//    return YES;    
+}
+
+- (BOOL)handleOpenURL:(NSURL*)url
+{
+  NSString* scheme = [url scheme];
+  NSString* prefix = [NSString stringWithFormat:@"fb%@", SHKCONFIG(facebookAppId)];
+  if ([scheme hasPrefix:prefix])
+  return [SHKFacebook handleOpenURL:url];
+  return YES;
+}
+
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation 
+{
+  return [self handleOpenURL:url];
+}
+
+
+
+- (void) dealloc
+{
+	[super dealloc];
+}
+
+@end

--- a/iOS/ShareKitPlugin/example-config/MySHKConfiguration.h
+++ b/iOS/ShareKitPlugin/example-config/MySHKConfiguration.h
@@ -1,0 +1,12 @@
+//
+//  MySHKConfiguration.h
+//  Socializer
+//
+//  Created by Kerri Shotts on 5/29/12.
+//
+
+#import "DefaultSHKConfigurator.h"
+
+@interface MySHKConfiguration : DefaultSHKConfigurator
+
+@end

--- a/iOS/ShareKitPlugin/example-config/MySHKConfiguration.m
+++ b/iOS/ShareKitPlugin/example-config/MySHKConfiguration.m
@@ -1,0 +1,102 @@
+//
+//  MySHKConfiguration.m
+//  Socializer
+//
+//  Created by Kerri Shotts on 5/29/12.
+//
+
+#import "MySHKConfiguration.h"
+
+@implementation MySHKConfiguration
+/* 
+ App Description 
+ ---------------
+ These values are used by any service that shows 'shared from XYZ'
+ */
+- (NSString*)appName {
+	return @"MyApp";
+}
+
+- (NSString*)appURL {
+	return @"http://www.example.com";
+}
+
+// Facebook - https://developers.facebook.com/apps
+// SHKFacebookAppID is the Application ID provided by Facebook
+// SHKFacebookLocalAppID is used if you need to differentiate between several iOS apps running against a single Facebook app. Useful, if you have full and lite versions of the same app,
+// and wish sharing from both will appear on facebook as sharing from one main app. You have to add different suffix to each version. Do not forget to fill both suffixes on facebook developer ("URL Scheme Suffix"). Leave it blank unless you are sure of what you are doing. 
+// The CFBundleURLSchemes in your App-Info.plist should be "fb" + the concatenation of these two IDs.
+// Example: 
+//    SHKFacebookAppID = 555
+//    SHKFacebookLocalAppID = lite
+// 
+//    Your CFBundleURLSchemes entry: fb555lite
+- (NSString*)facebookAppId {
+	return @"1234567890";
+}
+
+- (NSString*)facebookLocalAppId {
+	return @"";
+}
+
+//Change if your app needs some special Facebook permissions only. In most cases you can leave it as it is.
+- (NSArray*)facebookListOfPermissions {    
+    return [NSArray arrayWithObjects:@"publish_stream", @"offline_access", nil];
+}
+
+// Read It Later - http://readitlaterlist.com/api/signup/ 
+- (NSString*)readItLaterKey {
+	return @"12342517293587192873491287351298374";
+}
+
+// Twitter - http://dev.twitter.com/apps/new
+/*
+ Important Twitter settings to get right:
+ 
+ Differences between OAuth and xAuth
+ --
+ There are two types of authentication provided for Twitter, OAuth and xAuth.  OAuth is the default and will
+ present a web view to log the user in.  xAuth presents a native entry form but requires Twitter to add xAuth to your app (you have to request it from them).
+ If your app has been approved for xAuth, set SHKTwitterUseXAuth to 1.
+ 
+ Callback URL (important to get right for OAuth users)
+ --
+ 1. Open your application settings at http://dev.twitter.com/apps/
+ 2. 'Application Type' should be set to BROWSER (not client)
+ 3. 'Callback URL' should match whatever you enter in SHKTwitterCallbackUrl.  The callback url doesn't have to be an actual existing url.  The user will never get to it because ShareKit intercepts it before the user is redirected.  It just needs to match.
+ */
+
+/*
+ If you want to force use of old-style, pre-IOS5 twitter framework, for example to ensure
+ twitter accounts don't end up in the devices account store, set this to true.
+ */
+- (NSNumber*)forcePreIOS5TwitterAccess {
+	return [NSNumber numberWithBool:true];
+}
+
+- (NSString*)twitterConsumerKey {
+	return @"13412531253123425341";
+}
+
+- (NSString*)twitterSecret {
+	return @"1234123516413634573456235423451234";
+}
+// You need to set this if using OAuth, see note above (xAuth users can skip it)
+- (NSString*)twitterCallbackUrl {
+	return @"http://www.example.com/callback";
+}
+// To use xAuth, set to 1
+- (NSNumber*)twitterUseXAuth {
+	return [NSNumber numberWithInt:0];
+}
+// Enter your app's twitter account if you'd like to ask the user to follow it when logging in. (Only for xAuth)
+- (NSString*)twitterUsername {
+	return @"";
+}
+
+/* Name of the plist file that defines the class names of the sharers to use. Usually should not be changed, but this allows you to subclass a sharer and have the subclass be used. Also helps, if you want to exclude some sharers - you can create your own plist, and add it to your project. This way you do not need to change original SHKSharers.plist, which is a part of subproject - this allows you upgrade easily as you did not change ShareKit itself */
+- (NSString*)sharersPlistName {
+	return @"MySHKSharers.plist";
+}
+
+@end


### PR DESCRIPTION
Given that the prior plugin was out of date, I thought I'd update it to work with Cordova 1.7. Along the way I discovered that ShareKit hasn't been updated in forever, and doesn't work correctly on iOS 5. So I switched to ShareKit 2.0 (a community-maintained fork at https://github.com/ShareKit/ShareKit) in my own project and updated the plugin to work with it. It _might_ work with the old ShareKit -- I haven't tried.

I've not done anything relating to iOS ARC -- for now ARC should be disabled for the plugin Objective-C files and for Sharekit 2.0.
