### PR TITLE
[iOS/Twitter] Add a more general Twitter API request method

### DIFF
--- a/iOS/Twitter/example/www/demo.js
+++ b/iOS/Twitter/example/www/demo.js
@@ -17,7 +17,7 @@ TwitterDemo = {
     },
     
     setup:function(){
-        var tests = ["isAvailable", "isSetup", "tweet1", "tweet2", "tweet3", "tweet4", "tweet5", "tweet6", "timeline", "mentions"];
+        var tests = ["isAvailable", "isSetup", "tweet1", "tweet2", "tweet3", "tweet4", "tweet5", "tweet6", "timeline", "mentions", "friendsIds", "usersLookup"];
         for(var i=0, l=tests.length; i<l; i++){
             this.$(tests[i]).onclick = this[tests[i]];
         }
@@ -126,6 +126,26 @@ TwitterDemo = {
         window.plugins.twitter.getMentions(
             function(s){ TwitterDemo.log("mentions success: " + JSON.stringify(s)); }, 
             function(e){ TwitterDemo.log("mentions failure: " + e); });
+    },
+    
+    friendsIds:function(){
+        TwitterDemo.log("wait..");
+        window.plugins.twitter.getTWRequest(
+            'friends/ids.json',
+            {},
+            function(s){ TwitterDemo.log("friendsIds success: " + JSON.stringify(s)); }, 
+            function(e){ TwitterDemo.log("friendsIds failure: " + e); });
+    },
+    
+    usersLookup:function(){
+        TwitterDemo.log("wait..");
+        window.plugins.twitter.getTWRequest(
+            'users/lookup.json',
+            {user_id: '16141659,783214,6253282'},
+            function(s){ TwitterDemo.log("usersLookup success: " + JSON.stringify(s)); }, 
+            function(e){ TwitterDemo.log("usersLookup failure: " + e); },
+            {requestMethod: 'POST'});
     }
+    
     
 };

--- a/iOS/Twitter/example/www/index.html
+++ b/iOS/Twitter/example/www/index.html
@@ -25,7 +25,9 @@
 		<li><a href="#" id="tweet5">tweet (empty)</a></li>
 		<li><a href="#" id="timeline">timeline</a></li>
 		<li><a href="#" id="mentions">mentions</a></li>
+		<li><a href="#" id="friendsIds">friendsIds</a></li>
+		<li><a href="#" id="usersLookup">usersLookup</a></li>
 	</ol>
-	<div id="log" style="width:100%;height:200px;overflow:auto;background-color:#000;color:yellow;"></div>
+	<div id="log" style="width:100%;height:400px;overflow:auto;background-color:#000;color:yellow;"></div>
   </body>
 </html>

--- a/iOS/Twitter/example/www/index.html
+++ b/iOS/Twitter/example/www/index.html
@@ -7,7 +7,7 @@
 	<meta charset="utf-8">
 
 
-    <script type="text/javascript" charset="utf-8" src="cordova-1.5.0.js"></script>
+    <script type="text/javascript" charset="utf-8" src="cordova-1.7.0.js"></script>
     <script type="text/javascript" charset="utf-8" src="TwitterPlugin.js"></script>
     <script type="text/javascript" charset="utf-8" src="demo.js"></script>
   </head>

--- a/iOS/Twitter/native/ios/TwitterPlugin.h
+++ b/iOS/Twitter/native/ios/TwitterPlugin.h
@@ -29,6 +29,8 @@
 
 - (void) getMentions:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
 
+- (void) getTWRequest:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+
 - (void) performCallbackOnMainThreadforJS:(NSString*)js;
 
 @end

--- a/iOS/Twitter/www/TwitterPlugin.js
+++ b/iOS/Twitter/www/TwitterPlugin.js
@@ -26,6 +26,13 @@ Twitter.prototype.getTwitterUsername = function(response){
     cordova.exec(response, null, "TwitterPlugin", "getTwitterUsername", []);
 };
 
+Twitter.prototype.getTWRequest = function(url, params, success, failure, options){
+    options = options || {};
+    options.url = url;
+    options.params = params;
+    cordova.exec(success, failure, "TwitterPlugin", "getTWRequest", [options]);
+};
+
 cordova.addConstructor(function() {
 					   
 					   /* shim to work in 1.5 and 1.6  */


### PR DESCRIPTION
It wouldn't be practical to write a Phonegap helper function for every Twitter API resources, so here's a more general TWRequest encapsulation.

It supports passing a JS array of parameters, and the request method as an option (defaults to GET).

Example:

<pre>
friendsIds:function(){
    TwitterDemo.log("wait..");
    window.plugins.twitter.getTWRequest(
        'friends/ids.json',
        {},
        function(s){ TwitterDemo.log("friendsIds success: " + JSON.stringify(s)); }, 
        function(e){ TwitterDemo.log("friendsIds failure: " + e); });
},

usersLookup:function(){
    TwitterDemo.log("wait..");
    window.plugins.twitter.getTWRequest(
        'users/lookup.json',
        {user_id: '16141659,783214,6253282'},
        function(s){ TwitterDemo.log("usersLookup success: " + JSON.stringify(s)); }, 
        function(e){ TwitterDemo.log("usersLookup failure: " + e); },
        {requestMethod: 'POST'});
}
</pre>
