### PR TITLE
Intent crashes causing app to crash

### DIFF
--- a/Android/WebIntent/WebIntent.java
+++ b/Android/WebIntent/WebIntent.java
@@ -148,9 +148,15 @@ public class WebIntent extends Plugin {
 
     void startActivity(String action, Uri uri, String type, Map<String, String> extras) {
         Intent i = (uri != null ? new Intent(action, uri) : new Intent(action));
-        if (type != null) {
-            i.setType(type);
+        
+        if (type != null && uri != null) {
+            i.setDataAndType(type, uri); //Fix the crash problem with android 2.3.6
+        } else {
+            if (type != null) {
+                i.setType(type);
+            }
         }
+        
         for (String key : extras.keySet()) {
             String value = extras.get(key);
             // If type is text html, the extra text must sent as HTML


### PR DESCRIPTION
This request is to fix a problem that appear in my samsung (android 2.3.6) and nexus one (2.2). I had a problem starting an activity (the activity launched but crashed directly, causing my app to crash also).

Instead of using setType, if there is a uri and a type, using i.setDataAndType(uri, type); fixed my problem.
It now works on android 2.3.6, so I thought you may be interested by this modification.
