### PR TITLE
[iOS] LowLatencyAudio - Fixed loop() stopping all voices bug on iOS

### DIFF
--- a/iOS/LowLatencyAudio/src/LowLatencyAudioAsset.m
+++ b/iOS/LowLatencyAudio/src/LowLatencyAudioAsset.m
@@ -67,7 +67,6 @@
 
 - (void) loop
 {
-    [self stop];
     AVAudioPlayer * player = [voices objectAtIndex:playIndex];
     [player setCurrentTime:0.0];
     player.numberOfLoops = -1;


### PR DESCRIPTION
The `loop()` function implements polyphony-supporting logic, yet
calls `stop()` before starting to play the audio (which kills all
the other voices, making it impossible to have multiple loops of
the same asset unless you preload it again with another id).

This makes no sense, so I removed that call to `stop()`.
