### PR TITLE
Android Share plugin work with Cordova-1.9.0

### DIFF
--- a/Android/Share/Share.java
+++ b/Android/Share/Share.java
@@ -34,7 +34,7 @@ public class Share extends Plugin {
 		sendIntent.setType("text/plain");
 		sendIntent.putExtra(android.content.Intent.EXTRA_SUBJECT, subject);
 		sendIntent.putExtra(android.content.Intent.EXTRA_TEXT, text);
-		this.ctx.startActivity(sendIntent);
+		this.cordova.startActivityForResult(this, sendIntent, 0);
 	}
 
 }


### PR DESCRIPTION
Fixes to the Share Plugin that was broken because of the removal of the 'startActivity' method from the Plugin class in Cordova-1.9.0.
