### PR TITLE
[Android] BluetoothPlugin - Add connectInsecure() analogous to connect()

### DIFF
--- a/Android/BluetoothPlugin/assets/www/bluetooth.js
+++ b/Android/BluetoothPlugin/assets/www/bluetooth.js
@@ -79,6 +79,16 @@ cordova.define("cordova/plugin/bluetooth", function(require, exports, module) {
 	Bluetooth.prototype.connect = function(successCallback,failureCallback,address,uuid) {
 	    return exec(successCallback, failureCallback, 'BluetoothPlugin', 'connect', [address, uuid]);
 	}
+
+	/**
+	 * Open an insecure RFComm channel for a given device & uuid endpoint
+	 * 
+	 * @param successCallback function to be called when the connection was successfull. Passed parameter is an integer containing the socket id for the connection
+	 * @param errorCallback function to be called when there was a problem while opening the connection
+	 */
+	Bluetooth.prototype.connectInsecure = function(successCallback,failureCallback,address,uuid) {
+	    return exec(successCallback, failureCallback, 'BluetoothPlugin', 'connectInsecure', [address, uuid]);
+	}
 	
 	/**
 	 * Close a RFComm channel for a given socket-id

--- a/Android/BluetoothPlugin/src/org/apache/cordova/plugin/BluetoothPlugin.java
+++ b/Android/BluetoothPlugin/src/org/apache/cordova/plugin/BluetoothPlugin.java
@@ -46,6 +46,7 @@ public class BluetoothPlugin extends Plugin {
 	private static final String ACTION_DISCOVERDEVICES = "discoverDevices";
 	private static final String ACTION_GETUUIDS = "getUUIDs";
 	private static final String ACTION_CONNECT = "connect";
+	private static final String ACTION_CONNECTINSECURE = "connectInsecure";
 	private static final String ACTION_READ = "read";
 	private static final String ACTION_DISCONNECT = "disconnect";
 	
@@ -188,6 +189,30 @@ public class BluetoothPlugin extends Plugin {
 
 				BluetoothDevice bluetoothDevice = m_bluetoothAdapter.getRemoteDevice(address);
 				BluetoothSocket bluetoothSocket = bluetoothDevice.createRfcommSocketToServiceRecord(uuid);
+				
+				bluetoothSocket.connect();
+				
+				m_bluetoothSockets.add(bluetoothSocket);
+				int socketId = m_bluetoothSockets.indexOf(bluetoothSocket);
+				
+				pluginResult = new PluginResult(PluginResult.Status.OK, socketId);
+			}
+			catch( Exception e ) {
+				Log.e("BluetoothPlugin", e.toString() + " / " + e.getMessage() );
+				
+				pluginResult = new PluginResult(PluginResult.Status.JSON_EXCEPTION, e.getMessage());
+			}
+		}
+		// Insecurely connect to a given device & uuid endpoint
+		else if( ACTION_CONNECTINSECURE.equals(action) ) {
+			try {
+				String address = args.getString(0);
+				UUID uuid = UUID.fromString(args.getString(1));
+				
+				Log.d( "BluetoothPlugin", "Connecting insecure..." );
+
+				BluetoothDevice bluetoothDevice = m_bluetoothAdapter.getRemoteDevice(address);
+				BluetoothSocket bluetoothSocket = bluetoothDevice.createInsecureRfcommSocketToServiceRecord(uuid);
 				
 				bluetoothSocket.connect();
 				


### PR DESCRIPTION
1. to allow unpaired/insecure connections to peripherials requiring so, such as some GPSes, Barcode Scanners, etc., see e.g. http://stackoverflow.com/questions/10986573/programmtically-connecting-to-a-bluetooth-enabled-barcode-scanner-in-android
2. As a last-effort workaround for well-known situation in ICS, where some devices will not work if paired, with Androids reauthentication failing, see e.g. http://code.google.com/p/android/issues/detail?id=34161 and http://stackoverflow.com/questions/11082819/bluetooth-connection-on-android-ics-not-possible
