### PR TITLE
[iOS] Fix #ifdef left from phonegap days

### DIFF
--- a/iOS/ChildBrowser/ChildBrowserCommand.h
+++ b/iOS/ChildBrowser/ChildBrowserCommand.h
@@ -11,9 +11,7 @@
 #import "ChildBrowserViewController.h"
 
 
-#ifdef CORDOVA_FRAMEWORK
-    @interface ChildBrowserCommand : CDVPlugin <ChildBrowserDelegate>  {
-#endif
+@interface ChildBrowserCommand : CDVPlugin <ChildBrowserDelegate>  {
     ChildBrowserViewController* childBrowser;
 }
 


### PR DESCRIPTION
This shows up with new cordova 2 projects where cordova is
not a framework, but looks like it should have been removed
with the other conditions from phonegap.
