### PR TITLE
[iOS] ShareKit - Fixing 'share' method

### DIFF
--- a/iOS/ShareKitPlugin/ShareKitPlugin.m
+++ b/iOS/ShareKitPlugin/ShareKitPlugin.m
@@ -25,7 +25,8 @@
     
     NSString *message = [arguments objectAtIndex:1];
     SHKItem *item;
-    if ([arguments objectAtIndex:2]==NULL) {
+
+    if ([arguments count] == 3) {
         NSURL *itemUrl = [NSURL URLWithString:[arguments objectAtIndex:2]];  
         item = [SHKItem URL:itemUrl title:message contentType:SHKURLContentTypeWebpage];
     } else {


### PR DESCRIPTION
'share' method takes two arguments: message and url.
When used on iOS, the url is being ignored
