### PR TITLE
[Android][iOS] Fix and Add getPage support: Android and iOS.

### DIFF
--- a/Android/ChildBrowser/2.0.0/src/com/phonegap/plugins/childBrowser/ChildBrowser.java
+++ b/Android/ChildBrowser/2.0.0/src/com/phonegap/plugins/childBrowser/ChildBrowser.java
@@ -87,6 +87,24 @@ public class ChildBrowser extends Plugin {
                     pluginResult.setKeepCallback(true);
                     return pluginResult;
                 }
+            } else if (action.equals("getPage")) {
+                this.browserCallbackId = callbackId;
+
+                // If the ChildBrowser isnt already open then throw an error
+                if (dialog == null || !dialog.isShowing()) {
+                    return new PluginResult(PluginResult.Status.ERROR, "ChildBrowser isn't open yet.");
+                }
+
+                result = this.getPage(args.getString(0), args.optJSONObject(1));
+
+                if (result.length() > 0) {
+                    status = PluginResult.Status.ERROR;
+                    return new PluginResult(status, result);
+                } else {
+                    PluginResult pluginResult = new PluginResult(status, result);
+                    pluginResult.setKeepCallback(true);
+                    return pluginResult;
+                }
             }
             else if (action.equals("close")) {
                 closeDialog();
@@ -199,6 +217,11 @@ public class ChildBrowser extends Plugin {
      */
     private boolean getShowLocationBar() {
         return this.showLocationBar;
+    }
+
+    public String getPage(final String url, JSONObject options) {
+        webview.loadUrl(url);
+        return "";
     }
 
     /**

--- a/Android/ChildBrowser/2.0.0/www/childbrowser.js
+++ b/Android/ChildBrowser/2.0.0/www/childbrowser.js
@@ -32,6 +32,15 @@ ChildBrowser.prototype.showWebPage = function(url, options) {
 };
 
 /**
+ * Display a new url in the existing browser.
+ *
+ * @param url           The url to load
+ */
+ChildBrowser.prototype.getPage = function(url, options) {
+    cordova.exec(this._onEvent, this._onError, "ChildBrowser", "getPage", [url ]);
+};
+
+/**
  * Close the browser opened by showWebPage.
  */
 ChildBrowser.prototype.close = function() {

--- a/iOS/ChildBrowser/ChildBrowser.js
+++ b/iOS/ChildBrowser/ChildBrowser.js
@@ -49,6 +49,12 @@ ChildBrowser.prototype.showWebPage = function(loc)
     cordovaRef.exec("ChildBrowserCommand.showWebPage", loc);
 };
 
+// Show a new page in an existing child browser
+ChildBrowser.prototype.getPage = function(loc)
+{
+    cordovaRef.exec("ChildBrowserCommand.getPage", loc);
+};
+
 // close the browser, will NOT result in close callback
 ChildBrowser.prototype.close = function()
 {

--- a/iOS/ChildBrowser/ChildBrowserCommand.h
+++ b/iOS/ChildBrowser/ChildBrowserCommand.h
@@ -17,6 +17,7 @@
 
 
 - (void) showWebPage:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
--(void) onChildLocationChange:(NSString*)newLoc;
+- (void) getPage:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+- (void) onChildLocationChange:(NSString*)newLoc;
 
 @end


### PR DESCRIPTION
Hey for some reason this function was added but never exposed for javascript on iOS

I've done so as I need it for a project I'm working on. 

Sidenote: using this method we got Facebook mobile comments working in PhoneGap (on iOS for now).

Also I added getPage in the Android plugin too.
