### PR TITLE
[Android] - fix plugin initialization for cordova 2.0.0

### DIFF
--- a/Android/Globalization/globalization.js
+++ b/Android/Globalization/globalization.js
@@ -506,10 +506,16 @@ Globalization.prototype.getCurrencyPattern = function(currencyCode, successCB, f
 		console.log("Globalization.getCurrencyPattern Error: currencyCode is not a currency code");
 	}
 };
-cordova.addConstructor(function()
-{
-	cordova.addPlugin('globalization', new Globalization());
-});
+
+if( cordova.addConstructor && cordova.addPlugin ){
+	cordova.addConstructor( function(){
+		cordova.addPlugin('globalization', new Globalization());
+	});
+}
+else{
+	window.plugins = window.plugins || {};
+	window.plugins.globalization = window.plugins.globalization || new Globalization();
+}
 
 GlobalizationError = function() {
 	this.code = null;


### PR DESCRIPTION
Hi, I've just upgraded to Cordova 2.0.0 and Globalization stopped working for me.

Here's a proposed fix, it should be backwards compatible.
