### PR TITLE
[iOS] DatePicker - Added allowFutureDates option.

### DIFF
--- a/iOS/DatePicker/DatePicker.js
+++ b/iOS/DatePicker/DatePicker.js
@@ -39,7 +39,8 @@ if (!window.plugins.datePicker) {
         var defaults = {
             mode: 'datetime',
             date: '',
-            allowOldDates: true
+            allowOldDates: true,
+            allowFutureDates : true
         }
         for (var key in defaults) {
             if (typeof options[key] !== "undefined")

--- a/iOS/DatePicker/DatePicker.m
+++ b/iOS/DatePicker/DatePicker.m
@@ -158,6 +158,7 @@
  	NSString *mode = [optionsOrNil objectForKey:@"mode"];
 	NSString *dateString = [optionsOrNil objectForKey:@"date"];
 	BOOL allowOldDates = NO;
+	BOOL allowFutureDates = YES;
 
 	if ([[optionsOrNil objectForKey:@"allowOldDates"] intValue] == 1) {
 		allowOldDates = YES;
@@ -165,6 +166,14 @@
 
 	if ( ! allowOldDates) {
 		self.datePicker.minimumDate = [NSDate date];
+	}
+	
+	if ([[optionsOrNil objectForKey:@"allowFutureDates"] intValue] == 0) {
+		allowFutureDates = NO;
+	}
+
+	if ( ! allowFutureDates) {
+		self.datePicker.maximumDate = [NSDate date];
 	}
 
 	self.datePicker.date = [self.isoDateFormatter dateFromString:dateString];


### PR DESCRIPTION
Currently the options only allow setting whether old dates can be
selected. This adds support for disabling selection of dates in the
future.
