### PR TITLE
[iOS] Fix GoogleAnalyticsPlugin reference error in Cordova 2.0.0 (#763)

### DIFF
--- a/iOS/GoogleAnalytics/GoogleAnalyticsPlugin.h
+++ b/iOS/GoogleAnalytics/GoogleAnalyticsPlugin.h
@@ -9,11 +9,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#ifdef CORDOVA_FRAMEWORK
 #import <Cordova/CDVPlugin.h>
-#else
-#import "CDVPlugin.h"
-#endif
 #import "GANTracker.h"
 
 @interface GoogleAnalyticsPlugin : CDVPlugin <GANTrackerDelegate> {


### PR DESCRIPTION
Error: _'CDVPlugin.h' file not found_

in GoogleAnalyticsPlugin.h
