### PR TITLE
[iOS] Display the message in the SMS and Email sharer body

### DIFF
--- a/iOS/ShareKitPlugin/ShareKitPlugin.m
+++ b/iOS/ShareKitPlugin/ShareKitPlugin.m
@@ -29,6 +29,7 @@
     if ([arguments count] == 3) {
         NSURL *itemUrl = [NSURL URLWithString:[arguments objectAtIndex:2]];  
         item = [SHKItem URL:itemUrl title:message contentType:SHKURLContentTypeWebpage];
+        item.text = message;
     } else {
         item = [SHKItem text:message];
     }


### PR DESCRIPTION
If you are invoking a web page (URL) share type in the SMS sharer, only the URL will be visible in the SMS compose field and the message will be lost.

This fix displays the message followed by the URL.
