### PR TITLE
[Android] Added support to handle sub-folders

### DIFF
--- a/Android/ExtractZipFile/src/com/phonegap/plugin/ExtractZipFile/ExtractZipFilePlugin.java
+++ b/Android/ExtractZipFile/src/com/phonegap/plugin/ExtractZipFile/ExtractZipFilePlugin.java
@@ -53,8 +53,16 @@ public class ExtractZipFilePlugin extends Plugin {
 					  int count;
 					  byte data[] = new byte[102222];
 					  String fileName = dirToInsert + entry.getName();
+					  
+					  // create folders, if needed, before extraction process
+					  if ( entry.getName().indexOf(File.separator) > -1 ) {
+						  String dirtobuild = entry.getName().substring(0, entry.getName().lastIndexOf(File.separator));
+						  File outFile1 = new File(dirToInsert + dirtobuild);
+						  outFile1.mkdirs();
+					  }
+					  // this will just handle empty folders then...
 					  File outFile = new File(fileName);
-					  if (entry.isDirectory()) 
+					  if (!entry.isDirectory()) 
 					  {
 						  outFile.mkdirs();
 					  } 


### PR DESCRIPTION
Been getting errors with ZIP files that has folders and sub-folders.

I added a little something to support sub-folders and sub-sub-folders
and on and on. I realize that entry from ZipFile just comes together
complete with its own folder paths. So I attempt to create them first
before the extracting process.

I hope you find this useful.
