### PR TITLE
[Android] Use of options==="undefined" is incorrect.

### DIFF
--- a/Android/ChildBrowser/1.8.1/www/childbrowser.js
+++ b/Android/ChildBrowser/1.8.1/www/childbrowser.js
@@ -23,10 +23,9 @@ ChildBrowser.LOCATION_CHANGED_EVENT = 1;
  * @param options       An object that specifies additional options
  */
 ChildBrowser.prototype.showWebPage = function(url, options) {
-    if (options === null || options === "undefined") {
-        var options = new Object();
-        options.showLocationBar = true;
-    }
+    options = options || {
+        showLocationBar: true
+    };
     cordova.exec(this._onEvent, this._onError, "ChildBrowser", "showWebPage", [url, options]);
 };
 


### PR DESCRIPTION
undefined is a datatype, not a string.
If options is not given, the showWebPage will result in error.
