### PR TITLE
[iOS] DatePicker.js: Initialize window.plugins

### DIFF
--- a/iOS/DatePicker/DatePicker.js
+++ b/iOS/DatePicker/DatePicker.js
@@ -4,6 +4,8 @@
 	MIT Licensed
 **/
 
+window.plugins || (window.plugins = {});
+
 if (!window.plugins.datePicker) {
 
     /* shim to work in 1.5 and 1.6 */
@@ -58,10 +60,6 @@ if (!window.plugins.datePicker) {
 
 
     Cordova.addConstructor(function() {
-        if(!window.plugins)
-        {
-            window.plugins = {};
-        }
         window.plugins.datePicker = new DatePicker();
     });
 };


### PR DESCRIPTION
The previous version of this file also initialized `window.plugins`, but it was after asking for `window.plugins.datePicker`, which caused an error if window.plugins was not initialized (that's the case if only the cordova 2.0 js is included before this plugin).
