### PR TITLE
Fixed invalid check in set and added clear option

### DIFF
--- a/Android/AppPreferences/2.0.0/assets/www/applicationPreferences.js
+++ b/Android/AppPreferences/2.0.0/assets/www/applicationPreferences.js
@@ -26,6 +26,10 @@ cordova.define("cordova/plugin/applicationpreferences", function(require, export
 	    cordova.exec(success,fail,"applicationPreferences","show",[activity]);    
 	};
 	
+	AppPreferences.prototype.clear = function(success,fail) {
+	    cordova.exec(success,fail,"applicationPreferences","clear", []);    
+	};
+
 	var appPreferences = new AppPreferences();
 	module.exports = appPreferences;
 });

--- a/Android/AppPreferences/2.0.0/src/com/simonmacdonald/prefs/AppPreferences.java
+++ b/Android/AppPreferences/2.0.0/src/com/simonmacdonald/prefs/AppPreferences.java
@@ -40,18 +40,14 @@ public class AppPreferences extends Plugin {
                 }
             } else if (action.equals("set")) {
                 String key = args.getString(0);
-                String value = args.getString(1);
-                if (sharedPrefs.contains(key)) {
-                    Editor editor = sharedPrefs.edit();
-                    if ("true".equals(value.toLowerCase()) || "false".equals(value.toLowerCase())) {
-                        editor.putBoolean(key, Boolean.parseBoolean(value));
-                    } else {
-                        editor.putString(key, value);
-                    }
-                    return new PluginResult(status, editor.commit());
+                String value = args.getString(1);               
+                Editor editor = sharedPrefs.edit();
+                if ("true".equals(value.toLowerCase()) || "false".equals(value.toLowerCase())) {
+                    editor.putBoolean(key, Boolean.parseBoolean(value));
                 } else {
-                    return createErrorObj(NO_PROPERTY, "No such property called " + key);
+                    editor.putString(key, value);
                 }
+                return new PluginResult(status, editor.commit());               
             } else if (action.equals("load")) {
                 JSONObject obj = new JSONObject();
                 Map prefs = sharedPrefs.getAll();
@@ -70,6 +66,10 @@ public class AppPreferences extends Plugin {
                 } catch (ActivityNotFoundException e) {
                     return createErrorObj(NO_PREFERENCE_ACTIVITY, "No preferences activity called " + activityName);
                 }
+            } else if (action.equals("clear")) {
+            	Editor editor = sharedPrefs.edit();
+            	editor.clear();
+            	return new PluginResult(status, editor.commit());
             }
         } catch (JSONException e) {
             status = PluginResult.Status.JSON_EXCEPTION;


### PR DESCRIPTION
Currently the "set" method checks whether the shared preferences has that value already with

``` java
if (sharedPrefs.contains(key)) 
```

which makes set method unable to be used to set a new value. The additonal check is incorrect, IMO.

Also added the code to clear all the shared preferences.
