### PR TITLE
[iOS] Set status bar hidden to no.

### DIFF
--- a/iOS/SMSComposer/SMSComposer.m
+++ b/iOS/SMSComposer/SMSComposer.m
@@ -53,7 +53,7 @@
 		[picker setRecipients:[ toRecipientsString componentsSeparatedByString:@","]];
 
 	[self.viewController presentModalViewController:picker animated:YES];
-	[[UIApplication sharedApplication] setStatusBarHidden:YES];///This hides the statusbar when the picker is presented -@RandyMcMillan
+	[[UIApplication sharedApplication] setStatusBarHidden:NO];///This hides the statusbar when the picker is presented -@RandyMcMillan
 	[picker release];
 	
 }


### PR DESCRIPTION
I think this should default to false as most apps do not run full screen/ status bar hidden mode (whatever you want to call it. Further more, when set to 'yes' my app ran into some issues. Upon canceling a text, the app stayed in full screen mode.
