### PR TITLE
[iOS] Add isCapable method to allow device capability detection

### DIFF
--- a/iPhone/Torch/Torch.h
+++ b/iPhone/Torch/Torch.h
@@ -17,5 +17,6 @@
 
 - (void) turnOn:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
 - (void) turnOff:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+- (void) isCapable:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
 
 @end

--- a/iPhone/Torch/Torch.h
+++ b/iPhone/Torch/Torch.h
@@ -7,22 +7,9 @@
 #import <Foundation/Foundation.h>
 #import <AVFoundation/AVFoundation.h>
 
-#ifdef PHONEGAP_FRAMEWORK
-#import <PhoneGap/PGPlugin.h>
-#endif
-
-#ifdef CORDOVA_FRAMEWORK
 #import <CORDOVA/CDVPlugin.h>
-#endif
 
-#ifdef PHONEGAP_FRAMEWORK
-@interface Torch : PGPlugin {
-#endif
-
-#ifdef CORDOVA_FRAMEWORK
 @interface Torch : CDVPlugin  {
-#endif
-
 	 AVCaptureSession* session;
 }
 

--- a/iPhone/Torch/Torch.js
+++ b/iPhone/Torch/Torch.js
@@ -10,20 +10,35 @@
 function Torch()
 {
 	this._isOn = false;
+	this._isCapable = false;
 	var self = this;
 	
+	cordova.exec(null, null, "Torch","isCapable", []);
 	this.__defineGetter__("isOn", function() { return self._isOn; });	
 }
 
 Torch.prototype.turnOn = function()
 {
-	PhoneGap.exec("Torch.turnOn");
+    if (this.isCapable())
+    {
+        console.log("Torch on");
+
+        cordova.exec("Torch.turnOn");
+    }
 };
 
 Torch.prototype.turnOff = function()
 {
-	PhoneGap.exec("Torch.turnOff");
+	console.log("Torch off");
+	
+	cordova.exec("Torch.turnOff");
 };
+
+Torch.prototype.isCapable = function()
+{
+	console.log("Capable: " + this._isCapable);
+	return this._isCapable;
+}
 
 Torch.install = function()
 {
@@ -33,4 +48,4 @@ Torch.install = function()
 	window.plugins.torch = new Torch();
 };
 
-PhoneGap.addConstructor(Torch.install);
+cordova.addConstructor(Torch.install);

--- a/iPhone/Torch/Torch.m
+++ b/iPhone/Torch/Torch.m
@@ -18,13 +18,7 @@
 
 @synthesize session;
 
-#ifdef PHONEGAP_FRAMEWORK
-- (PGPlugin*) initWithWebView:(UIWebView*)theWebView
-#endif
-
-#ifdef CORDOVA_FRAMEWORK
 - (CDVPlugin*) initWithWebView:(UIWebView*)theWebView
-#endif
 
 {
     self = (Torch*)[super initWithWebView:theWebView];

--- a/iPhone/Torch/Torch.m
+++ b/iPhone/Torch/Torch.m
@@ -78,16 +78,15 @@
 	if (captureDeviceClass != nil) {
 		
 		AVCaptureDevice* captureDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
-		
-		[captureDevice lockForConfiguration:nil];
-		
-		[captureDevice setTorchMode:AVCaptureTorchModeOn];
-		[captureDevice setFlashMode:AVCaptureFlashModeOn];
-		
-		[captureDevice unlockForConfiguration];
-		
-		[super writeJavascript:@"window.plugins.torch._isOn = true;"];
-	}	
+        [captureDevice lockForConfiguration:nil];
+        
+        [captureDevice setTorchMode:AVCaptureTorchModeOn];
+        [captureDevice setFlashMode:AVCaptureFlashModeOn];
+        
+        [captureDevice unlockForConfiguration];
+        
+        [super writeJavascript:@"window.plugins.torch._isOn = true;"];
+	}
 }
 
 - (void) turnOff:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options
@@ -96,16 +95,31 @@
 	if (captureDeviceClass != nil) 
 	{
 		AVCaptureDevice* captureDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
-		
-		[captureDevice lockForConfiguration:nil];
-		
-		[captureDevice setTorchMode:AVCaptureTorchModeOff];
-		[captureDevice setFlashMode:AVCaptureFlashModeOff];
-		
-		[captureDevice unlockForConfiguration];
+        
+        [captureDevice lockForConfiguration:nil];
+        
+        [captureDevice setTorchMode:AVCaptureTorchModeOff];
+        [captureDevice setFlashMode:AVCaptureFlashModeOff];
+        
+        [captureDevice unlockForConfiguration];
+        
+        [super writeJavascript:@"window.plugins.torch._isOn = false;"];
+	}
+}
 
-		[super writeJavascript:@"window.plugins.torch._isOn = false;"];
-	}	
+- (void) isCapable:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options;
+{
+    NSLog(@"running isCapable");
+    Class captureDeviceClass = NSClassFromString(@"AVCaptureDevice");
+    if (captureDeviceClass != nil)
+    {
+        AVCaptureDevice* captureDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
+        if ([captureDevice isTorchModeSupported:AVCaptureTorchModeOn])
+        {
+            NSLog(@"Torch is available.");
+            [super writeJavascript:@"window.plugins.torch._isCapable = true;"];
+        }
+    }
 }
 
 - (void) dealloc


### PR DESCRIPTION
The Android version of this plugin has an isCapable method to detect whether the device has a flash and can be used as a torch. These changes add that functionality to the iOS version.

Along the way, I've also removed the now-deprecated ifdef statements from the obj-C parts of the plugin.
