### PR TITLE
Update Android/StatusBarNotification/README.md

### DIFF
--- a/Android/StatusBarNotification/README.md
+++ b/Android/StatusBarNotification/README.md
@@ -17,6 +17,10 @@ Using this plugin requires [Android Cordova](http://github.com/apache/incubator-
 
     &lt;plugin name="StatusBarNotification" value="com.phonegap.plugins.statusBarNotification.StatusBarNotification"/&gt;
 
+   CAUTION: Using PhoneGap &ge; 2.0 (aka Cordova) you have to add this line into res/xml/config.xml in the &lt;plugins&gt;-section.
+The plugins.xml is no longer supported. The plugins are all located in the config.xml
+
+
 4. You will need to add a notification.png file to your applications res/drawable-ldpi, res/drawable-mdpi & res/drawable-hdpi or res/drawable-xhdpi directories (depending on what resolutions you want to support).
 
 5. You will need to add an import line like this to the .java files (see commented out lines inside the files):


### PR DESCRIPTION
Using PhoneGap 2.0 or higher (aka Cordova) the res/xml/plugins.xml is no longer supported.
Therefore the plugin must be added in the res/xml/config.xml in the <plugin>-section, which seems to be used from this time on.
