### PR TITLE
[iOS] BarcodeScanner changes for iOS 6, and bug fixes

### DIFF
--- a/iOS/BarcodeScanner/CDVBarcodeScanner.mm
+++ b/iOS/BarcodeScanner/CDVBarcodeScanner.mm
@@ -647,13 +647,16 @@ parentViewController:(UIViewController*)parentViewController
 }
 
 //--------------------------------------------------------------------------
-- (void)viewDidAppear:(BOOL)animated {
-    [self startCapturing];
-    
+- (void)viewWillAppear:(BOOL)animated {
     // this fixes the bug when the statusbar is landscape, and the preview layer
     // starts up in portrait (not filling the whole view)
     self.processor.previewLayer.frame = self.view.bounds;
+}
 
+//--------------------------------------------------------------------------
+- (void)viewDidAppear:(BOOL)animated {
+    [self startCapturing];
+    
     [super viewDidAppear:animated];
 }
 

--- a/iOS/BarcodeScanner/CDVBarcodeScanner.mm
+++ b/iOS/BarcodeScanner/CDVBarcodeScanner.mm
@@ -648,6 +648,10 @@ parentViewController:(UIViewController*)parentViewController
 
 //--------------------------------------------------------------------------
 - (void)viewWillAppear:(BOOL)animated {
+    
+    // set video orientation to what the camera sees
+    self.processor.previewLayer.orientation = [[UIApplication sharedApplication] statusBarOrientation];
+    
     // this fixes the bug when the statusbar is landscape, and the preview layer
     // starts up in portrait (not filling the whole view)
     self.processor.previewLayer.frame = self.view.bounds;

--- a/iOS/BarcodeScanner/CDVBarcodeScanner.mm
+++ b/iOS/BarcodeScanner/CDVBarcodeScanner.mm
@@ -85,7 +85,7 @@
 //------------------------------------------------------------------------------
 // view controller for the ui
 //------------------------------------------------------------------------------
-@interface CDVbcsViewController : UIViewController {}
+@interface CDVbcsViewController : UIViewController <CDVBarcodeScannerOrientationDelegate> {}
 @property (nonatomic, retain) CDVbcsProcessor*  processor;
 @property (nonatomic, retain) NSString*        alternateXib;
 @property (nonatomic)         BOOL             shutterPressed;

--- a/iOS/BarcodeScanner/CDVBarcodeScanner.mm
+++ b/iOS/BarcodeScanner/CDVBarcodeScanner.mm
@@ -16,11 +16,20 @@
 //------------------------------------------------------------------------------
 #import "zxing-all-in-one.h"
 
-#ifdef CORDOVA_FRAMEWORK
-#import <CORDOVA/CDVPlugin.h>
-#else
-#import "CDVPlugin.h"
-#endif
+#import <Cordova/CDVPlugin.h>
+
+
+//------------------------------------------------------------------------------
+// Delegate to handle orientation functions
+// 
+//------------------------------------------------------------------------------
+@protocol CDVBarcodeScannerOrientationDelegate <NSObject>
+
+- (NSUInteger)supportedInterfaceOrientations;
+- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation;
+- (BOOL)shouldAutorotate;
+
+@end
 
 //------------------------------------------------------------------------------
 // Adds a shutter button to the UI, and changes the scan from continuous to
@@ -81,6 +90,8 @@
 @property (nonatomic, retain) NSString*        alternateXib;
 @property (nonatomic)         BOOL             shutterPressed;
 @property (nonatomic, retain) IBOutlet UIView* overlayView;
+// unsafe_unretained is equivalent to assign - used to prevent retain cycles in the property below
+@property (nonatomic, unsafe_unretained) id orientationDelegate;
 
 - (id)initWithProcessor:(CDVbcsProcessor*)processor alternateOverlay:(NSString *)alternateXib;
 - (void)startCapturing;
@@ -238,6 +249,8 @@ parentViewController:(UIViewController*)parentViewController
     }
     
     self.viewController = [[[CDVbcsViewController alloc] initWithProcessor: self alternateOverlay:self.alternateXib] autorelease];
+    // here we set the orientation delegate to the MainViewController of the app (orientation controlled in the Project Settings)
+    self.viewController.orientationDelegate = self.plugin.viewController;
     
     // delayed [self openDialog];
     [self performSelector:@selector(openDialog) withObject:nil afterDelay:1];
@@ -637,19 +650,16 @@ parentViewController:(UIViewController*)parentViewController
 - (void)viewDidAppear:(BOOL)animated {
     [self startCapturing];
     
+    // this fixes the bug when the statusbar is landscape, and the preview layer
+    // starts up in portrait (not filling the whole view)
+    self.processor.previewLayer.frame = self.view.bounds;
+
     [super viewDidAppear:animated];
 }
 
 //--------------------------------------------------------------------------
 - (void)startCapturing {
     self.processor.capturing = YES;
-}
-
-//--------------------------------------------------------------------------
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {
-    // rotation currently not supported
-    if (interfaceOrientation == UIInterfaceOrientationPortrait) return YES;
-    return NO;
 }
 
 //--------------------------------------------------------------------------
@@ -798,6 +808,47 @@ parentViewController:(UIViewController*)parentViewController
     result = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
     return result;
+}
+
+#pragma mark CDVBarcodeScannerOrientationDelegate
+
+- (BOOL)shouldAutorotate
+{
+    if ((self.orientationDelegate != nil) && [self.orientationDelegate respondsToSelector:@selector(shouldAutorotate)]) {
+        return [self.orientationDelegate shouldAutorotate];
+    }
+    
+    return YES;
+}
+
+- (NSUInteger)supportedInterfaceOrientations
+{
+    if ((self.orientationDelegate != nil) && [self.orientationDelegate respondsToSelector:@selector(supportedInterfaceOrientations)]) {
+        return [self.orientationDelegate supportedInterfaceOrientations];
+    }
+    
+    return UIInterfaceOrientationMaskPortrait;
+}
+
+- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
+{
+    if ((self.orientationDelegate != nil) && [self.orientationDelegate respondsToSelector:@selector(shouldAutorotateToInterfaceOrientation:)]) {
+        return [self.orientationDelegate shouldAutorotateToInterfaceOrientation:interfaceOrientation];
+    }
+    
+    return YES;
+}
+
+- (void) willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)orientation duration:(NSTimeInterval)duration
+{
+    [CATransaction begin];
+    
+    self.processor.previewLayer.orientation = orientation;
+    [self.processor.previewLayer layoutSublayers];
+    self.processor.previewLayer.frame = self.view.bounds;
+    
+    [CATransaction commit];
+    [super willAnimateRotationToInterfaceOrientation:orientation duration:duration];
 }
 
 @end


### PR DESCRIPTION
- added orientation delegate: the orientation follows the supported orientation in the MainViewController of the app (thus the Project Settings orientation)
- bug fix: preview layer orientation when rotated to landscape was still in portrait
- bug fix: preview layer when rotated to landscape did not fill the whole view
- bug fix: when the statusbar is landscape at startup, the preview layer does not fill the whole view
