### PR TITLE
Phonegap to cordova

### DIFF
--- a/Android/SMSPlugin/src/net/practicaldeveloper/phonegap/plugins/SmsPlugin.java
+++ b/Android/SMSPlugin/src/net/practicaldeveloper/phonegap/plugins/SmsPlugin.java
@@ -29,8 +29,8 @@ import android.app.PendingIntent;
 import android.content.Intent;
 import android.telephony.SmsManager;
 
-import com.phonegap.api.Plugin;
-import com.phonegap.api.PluginResult;
+import org.apache.cordova.api.Plugin;
+import org.apache.cordova.api.PluginResult;
 
 public class SmsPlugin extends Plugin {
 	public final String ACTION_SEND_SMS = "SendSMS";


### PR DESCRIPTION
Changed "com.phonegap" to "org.apache.cordova" in two import messages (lines 32 and 33).

This should reflect the current state of the eco-system.
