### PR TITLE
ChildBrowser iOS6 bugfix: setting audio session category to "Playback"

### DIFF
--- a/iOS/ChildBrowser/ChildBrowserCommand.m
+++ b/iOS/ChildBrowser/ChildBrowserCommand.m
@@ -4,6 +4,7 @@
 
 #import "ChildBrowserCommand.h"
 #import <Cordova/CDVViewController.h>
+#import <AVFoundation/AVFoundation.h>
 
 @implementation ChildBrowserCommand
 
@@ -11,6 +12,14 @@
 
 - (void)showWebPage:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options  // args: url
 {
+    /* setting audio session category to "Playback" (since iOS 6) */
+    AVAudioSession *audioSession = [AVAudioSession sharedInstance];
+    NSError *setCategoryError = nil;
+    BOOL ok = [audioSession setCategory:AVAudioSessionCategoryPlayback error:&setCategoryError];
+    if (!ok) {
+        NSLog(@"Error setting AVAudioSessionCategoryPlayback: %@", setCategoryError);
+    };
+
     if (self.childBrowser == nil) {
 #if __has_feature(objc_arc)
         self.childBrowser = [[ChildBrowserViewController alloc] initWithScale:NO];

--- a/iOS/ChildBrowser/ChildBrowserCommand.m
+++ b/iOS/ChildBrowser/ChildBrowserCommand.m
@@ -4,6 +4,7 @@
 
 #import "ChildBrowserCommand.h"
 #import <Cordova/CDVViewController.h>
+#import <AVFoundation/AVFoundation.h>
 
 @implementation ChildBrowserCommand
 
@@ -11,6 +12,15 @@
 
 - (void)showWebPage:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options  // args: url
 {
+
+    /* setting audio session category to "Playback" (since iOS 6) */
+    AVAudioSession *audioSession = [AVAudioSession sharedInstance];
+    NSError *setCategoryError = nil;
+    BOOL ok = [audioSession setCategory:AVAudioSessionCategoryPlayback error:&setCategoryError];
+    if (!ok) {
+        NSLog(@"Error setting AVAudioSessionCategoryPlayback: %@", setCategoryError);
+    };
+
     if (self.childBrowser == nil) {
 #if __has_feature(objc_arc)
         self.childBrowser = [[ChildBrowserViewController alloc] initWithScale:NO];

--- a/iOS/ChildBrowser/ChildBrowserCommand.m
+++ b/iOS/ChildBrowser/ChildBrowserCommand.m
@@ -4,7 +4,6 @@
 
 #import "ChildBrowserCommand.h"
 #import <Cordova/CDVViewController.h>
-#import <AVFoundation/AVFoundation.h>
 
 @implementation ChildBrowserCommand
 
@@ -12,15 +11,6 @@
 
 - (void)showWebPage:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options  // args: url
 {
-
-    /* setting audio session category to "Playback" (since iOS 6) */
-    AVAudioSession *audioSession = [AVAudioSession sharedInstance];
-    NSError *setCategoryError = nil;
-    BOOL ok = [audioSession setCategory:AVAudioSessionCategoryPlayback error:&setCategoryError];
-    if (!ok) {
-        NSLog(@"Error setting AVAudioSessionCategoryPlayback: %@", setCategoryError);
-    };
-
     if (self.childBrowser == nil) {
 #if __has_feature(objc_arc)
         self.childBrowser = [[ChildBrowserViewController alloc] initWithScale:NO];


### PR DESCRIPTION
fixes #890
Tested on iOS 6 and iOS 5.0 (Simulator)
