### PR TITLE
Bug Fix and Added feature for Statusbar notification

### DIFF
--- a/Android/StatusBarNotification/README.md
+++ b/Android/StatusBarNotification/README.md
@@ -26,6 +26,11 @@ The plugins.xml is no longer supported. The plugins are all located in the confi
 5. You will need to add an import line like this to the .java files (see commented out lines inside the files):
 
 	import com.my.app.R; 
+6. If you need the notification to stick, you can pass a paramter to notify function. 
+	E.g.:
+	   window.plugins.statusBarNotification.notify("Put your title here", "Put your sticky message here", Flag.FLAG_NO_CLEAR);
+           //you can then use clear function to remove it.
+	   window.plugins.statusBarNotification.clear();
 	
 ## Using the plugin ##
 

--- a/Android/StatusBarNotification/StatusBarNotification.java
+++ b/Android/StatusBarNotification/StatusBarNotification.java
@@ -37,8 +37,6 @@ import android.app.Notification;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.content.Intent;
-
-import android.os.Handler;
 import android.util.Log;
 
 public class StatusBarNotification extends Plugin {
@@ -63,8 +61,10 @@ public class StatusBarNotification extends Plugin {
                 String tag = data.getString(0);
                 String title = data.getString(1);
                 String body = data.getString(2);
+                String flag = data.getString(3);
                 Log.d("NotificationPlugin", "Notification: " + tag + ", " + title + ", " + body);
-                showNotification(tag, title, body);
+                int notificationFlag = getFlagValue(flag);
+                showNotification(tag, title, body, notificationFlag);
                 result = new PluginResult(Status.OK);
             } catch (JSONException jsonEx) {
                 Log.d("NotificationPlugin", "Got JSON Exception "
@@ -76,6 +76,7 @@ public class StatusBarNotification extends Plugin {
                 String tag = data.getString(0);
                 Log.d("NotificationPlugin", "Notification cancel: " + tag);
                 clearNotification(tag);
+                result = new PluginResult(Status.OK);
             } catch (JSONException jsonEx) {
                 Log.d("NotificationPlugin", "Got JSON Exception " + jsonEx.getMessage());
                 result = new PluginResult(Status.JSON_EXCEPTION);
@@ -88,18 +89,37 @@ public class StatusBarNotification extends Plugin {
     }
 
     /**
+     * Helper method that returns a flag value to be used for notification
+     * by default it will return 16 representing FLAG_NO_CLEAR
+     * 
+     * @param flag
+     * @return int value of the flag
+     */
+    private int getFlagValue(String flag) {
+		int flagVal = Notification.FLAG_AUTO_CANCEL;
+		
+		// We trust the flag value as it comes from our JS constant.
+		// This is also backwards compatible as it will be emtpy.
+		if (!flag.isEmpty()){
+			flagVal = Integer.parseInt(flag);
+		}
+		
+		return flagVal;
+	}
+
+	/**
      * 	Displays status bar notification
      *
      * 	@param tag Notification tag.
      *  @param contentTitle	Notification title
      *  @param contentText	Notification text
      * */
-    public void showNotification( CharSequence tag, CharSequence contentTitle, CharSequence contentText ) {
+    public void showNotification( CharSequence tag, CharSequence contentTitle, CharSequence contentText, int flag) {
         String ns = Context.NOTIFICATION_SERVICE;
         context = cordova.getActivity().getApplicationContext();
         mNotificationManager = (NotificationManager) context.getSystemService(ns);
 
-        Notification noti = StatusNotificationIntent.buildNotification(context, tag, contentTitle, contentText);
+        Notification noti = StatusNotificationIntent.buildNotification(context, tag, contentTitle, contentText, flag);
         mNotificationManager.notify(tag.hashCode(), noti);
     }
 

--- a/Android/StatusBarNotification/StatusBarNotification.java
+++ b/Android/StatusBarNotification/StatusBarNotification.java
@@ -27,9 +27,8 @@
 
 package com.phonegap.plugins.statusBarNotification;
 
-import org.apache.cordova.api.Plugin;
-import org.apache.cordova.api.PluginResult;
-import org.apache.cordova.api.PluginResult.Status;
+import org.apache.cordova.api.CallbackContext;
+import org.apache.cordova.api.CordovaPlugin;
 import org.json.JSONArray;
 import org.json.JSONException;
 
@@ -39,7 +38,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
 
-public class StatusBarNotification extends Plugin {
+public class StatusBarNotification extends CordovaPlugin {
     //	Action to execute
     public static final String NOTIFY = "notify";
     public static final String CLEAR = "clear";
@@ -49,13 +48,13 @@ public class StatusBarNotification extends Plugin {
      *
      * 	@param action		Action to execute
      * 	@param data			JSONArray of arguments to the plugin
-     *  @param callbackId	The callback id used when calling back into JavaScript
+     *  @param callbackContext	The callback context used when calling back into JavaScript.
      *
      *  @return				A PluginRequest object with a status
      * */
     @Override
-    public PluginResult execute(String action, JSONArray data, String callbackId) {
-        PluginResult result = null;
+    public boolean execute(String action, JSONArray data, CallbackContext callbackContext) {
+        boolean actionValid = true;
         if (NOTIFY.equals(action)) {
             try {
                 String tag = data.getString(0);
@@ -65,27 +64,25 @@ public class StatusBarNotification extends Plugin {
                 Log.d("NotificationPlugin", "Notification: " + tag + ", " + title + ", " + body);
                 int notificationFlag = getFlagValue(flag);
                 showNotification(tag, title, body, notificationFlag);
-                result = new PluginResult(Status.OK);
             } catch (JSONException jsonEx) {
                 Log.d("NotificationPlugin", "Got JSON Exception "
                         + jsonEx.getMessage());
-                result = new PluginResult(Status.JSON_EXCEPTION);
+                actionValid = false;
             }
         } else if (CLEAR.equals(action)){
             try {
                 String tag = data.getString(0);
                 Log.d("NotificationPlugin", "Notification cancel: " + tag);
                 clearNotification(tag);
-                result = new PluginResult(Status.OK);
             } catch (JSONException jsonEx) {
                 Log.d("NotificationPlugin", "Got JSON Exception " + jsonEx.getMessage());
-                result = new PluginResult(Status.JSON_EXCEPTION);
+                actionValid = false;
             }
         } else {
-            result = new PluginResult(Status.INVALID_ACTION);
+            actionValid = false;
             Log.d("NotificationPlugin", "Invalid action : "+action+" passed");
         }
-        return result;
+        return actionValid;
     }
 
     /**
@@ -148,7 +145,7 @@ public class StatusBarNotification extends Plugin {
         // The incoming Intent may or may not have been for a notification.
         String tag = intent.getStringExtra("notificationTag");
         if (tag != null) {
-            sendJavascript("window.Notification.callOnclickByTag('"+ tag + "')");
+        	 this.webView.sendJavascript("window.Notification.callOnclickByTag('"+ tag + "')");
         }
     }
 

--- a/Android/StatusBarNotification/StatusNotificationIntent.java
+++ b/Android/StatusBarNotification/StatusNotificationIntent.java
@@ -1,6 +1,6 @@
 // This class is used on all Androids below Honeycomb
 package com.phonegap.plugins.statusBarNotification;
-// import com.yourapp.R;
+
 
 import android.app.Notification;
 import android.app.PendingIntent;
@@ -8,12 +8,14 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 
+//import com.my.app.R;
+
 public class StatusNotificationIntent {
-    public static Notification buildNotification( Context context, CharSequence tag, CharSequence contentTitle, CharSequence contentText ) {
+    public static Notification buildNotification( Context context, CharSequence tag, CharSequence contentTitle, CharSequence contentText, int flag ) {
         int icon = R.drawable.notification;
         long when = System.currentTimeMillis();
         Notification noti = new Notification(icon, contentTitle, when);
-        noti.flags |= Notification.FLAG_AUTO_CANCEL;
+        noti.flags |= flag;
 
         PackageManager pm = context.getPackageManager();
         Intent notificationIntent = pm.getLaunchIntentForPackage(context.getPackageName());

--- a/Android/StatusBarNotification/statusbarnotification.js
+++ b/Android/StatusBarNotification/statusbarnotification.js
@@ -27,6 +27,15 @@
 
 var cordovaRef = window.PhoneGap || window.Cordova || window.cordova; // old to new fallbacks
 
+/** 
+ * Flags to denote the Android Notification constants
+ * Values are representation from Android Notification Flag bit vals 
+ */
+
+function Flag() {}
+Flag.FLAG_AUTO_CANCEL="16";
+Flag.FLAG_NO_CLEAR="32";
+
 /** @deprecated Use the W3C standard window.Notification API instead. */
 var NotificationMessenger = function() { }
 
@@ -35,10 +44,11 @@ var NotificationMessenger = function() { }
  * @param body Body of the notification
  * @deprecated Use the W3C standard window.Notification API instead.
  */
-NotificationMessenger.prototype.notify = function(title, body) {
+NotificationMessenger.prototype.notify = function(title, body, flag) {
     if (window.Notification) {
         this.activeNotification = new window.Notification(title, {
-            body: body
+            body: body,
+            flag: flag
         });
     }
 }
@@ -83,6 +93,8 @@ if (typeof window.Notification == 'undefined') {
         this.onclose = options.onclose;
 
         var content = options.body || '';
+        
+        var flag = options.flag || '';
 
         cordova.exec(function() {
             if (this.onshow) {
@@ -92,7 +104,7 @@ if (typeof window.Notification == 'undefined') {
             if (this.onerror) {
                 this.onerror(error);
             }
-        }, 'StatusBarNotification', 'notify', [this.tag, title, content]);
+        }, 'StatusBarNotification', 'notify', [this.tag, title, content, flag]);
     };
 
     // Permission is always granted on Android.


### PR DESCRIPTION
There was a bug on CLEAR action that would result in NPE. I have fixed that. Also Added feature so that users can have sticky notification (FLAG_NO_CLEAR).  The code is backwards compatible. It would be great feature to add.  
You can see sample implementation on my demo project  https://github.com/manijshrestha/PhonegapStatusNotificationDemo
Thank you,
