### PR TITLE
Fix for memory warnings due to AVCaptureSession leak

### DIFF
--- a/iOS/BarcodeScanner/CDVBarcodeScanner.mm
+++ b/iOS/BarcodeScanner/CDVBarcodeScanner.mm
@@ -300,7 +300,7 @@ parentViewController:(UIViewController*)parentViewController
 - (NSString*)setUpCaptureSession {
     NSError* error = nil;
     
-    AVCaptureSession* captureSession = [[AVCaptureSession alloc] init];
+    AVCaptureSession* captureSession = [[[AVCaptureSession alloc] init] autorelease];
     self.captureSession = captureSession;
     
     AVCaptureDevice* device = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];


### PR DESCRIPTION
AVCaptureSession wasn't being released and as such leaks memory. In our application it wasn't really an issue on iPhones but it becomes a problem fairly quickly (~80 scans) on low-memory devices such as the third and fourth generation iPod Touch.
