### PR TITLE
[iOS] GoogleAnalytics: handle empty 'value' arguments to trackEvent

### DIFF
--- a/iOS/GoogleAnalytics/GoogleAnalyticsPlugin.js
+++ b/iOS/GoogleAnalytics/GoogleAnalyticsPlugin.js
@@ -12,7 +12,7 @@ GoogleAnalyticsPlugin.prototype.trackEvent = function(category,action,label,valu
 	var options = {category:category,
 		action:action,
 		label:label,
-		value:value};
+		value:isNaN(parseInt(value)) ? -1 : value};
 	cordova.exec("GoogleAnalyticsPlugin.trackEvent",options);
 };
 


### PR DESCRIPTION
Passing a null 'value' argument to trackEvent would result in the following exception:

```
Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[NSNull intValue]: unrecognized selector sent to instance 0x3f6785e0'
```

Plugin now passes a negative integer for empty values, per GA iOS SDK documentation.
