### PR TITLE
FIX: DatePicker (IOS) breaks when the date value is invalid/missing.

### DIFF
--- a/iOS/DatePicker/DatePicker.m
+++ b/iOS/DatePicker/DatePicker.m
@@ -176,7 +176,11 @@
 		self.datePicker.maximumDate = [NSDate date];
 	}
 
-	self.datePicker.date = [self.isoDateFormatter dateFromString:dateString];
+	NSDate *date = [self.isoDateFormatter dateFromString:dateString];
+    if (!date) {
+        date = [NSDate date];
+    }
+    self.datePicker.date = date;
 
 	if ([mode isEqualToString:@"date"]) {
 		self.datePicker.datePickerMode = UIDatePickerModeDate;


### PR DESCRIPTION
The code that parses the dateString value returns nil when the dateString is missing or invalid.  But passing nil into the UIDatePicker's date property generates an error
