### PR TITLE
Added a HTTP request plugin

### DIFF
--- a/Android/HttpRequest/readme.md
+++ b/Android/HttpRequest/readme.md
@@ -1,0 +1,3 @@
+# HTTP request plugin for Phonegap / Cordova #
+
+Hosted at (https://github.com/bperin/HttpRequest)


### PR DESCRIPTION
Created a [plugin](https://github.com/bperin/HttpRequest)  that allows native HTTP requests. Basically a wrapper for a [HTTP library](https://github.com/kevinsawicki/http-request)  for android. Allows forced SSL connections. Currently supports POST and GET. Great for more secure access to API's
