### PR TITLE
[iOS] ChildBrowser: add .clear() method to flush CB history

### DIFF
--- a/iOS/ChildBrowser/ChildBrowser.js
+++ b/iOS/ChildBrowser/ChildBrowser.js
@@ -50,9 +50,16 @@ ChildBrowser.prototype.showWebPage = function(loc)
 };
 
 // close the browser, will NOT result in close callback
-ChildBrowser.prototype.close = function()
+ChildBrowser.prototype.close = function(clearInst)
 {
     cordovaRef.exec("ChildBrowserCommand.close");
+    if(clearInst) window.plugins.childBrowser.clear();
+};
+
+// clear the browser instance/history
+ChildBrowser.prototype.clear = function()
+{
+    cordovaRef.exec("ChildBrowserCommand.clear");
 };
 
 // Not Implemented

--- a/iOS/ChildBrowser/ChildBrowserCommand.m
+++ b/iOS/ChildBrowser/ChildBrowserCommand.m
@@ -54,6 +54,11 @@
     [self.childBrowser closeBrowser];
 }
 
+- (void)clear:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options
+{    
+    self.childBrowser = nil;
+}
+
 - (void)onClose
 {
     [self.webView stringByEvaluatingJavaScriptFromString:@"window.plugins.childBrowser.onClose();"];

--- a/iOS/GoogleAnalytics/GoogleAnalyticsPlugin.js
+++ b/iOS/GoogleAnalytics/GoogleAnalyticsPlugin.js
@@ -16,10 +16,11 @@ GoogleAnalyticsPlugin.prototype.trackEvent = function(category,action,label,valu
 	cordova.exec("GoogleAnalyticsPlugin.trackEvent",options);
 };
 
-GoogleAnalyticsPlugin.prototype.setCustomVariable = function(index,name,value) {
+GoogleAnalyticsPlugin.prototype.setCustomVariable = function(index,name,value,scope) {
 	var options = {index:index,
 		name:name,
-		value:value};
+		value:value,
+        scope:isNaN(parseInt(scope)) ? 3 : scope};  // page-level default
 	cordova.exec("GoogleAnalyticsPlugin.setCustomVariable",options);
 };
 

--- a/iOS/GoogleAnalytics/GoogleAnalyticsPlugin.m
+++ b/iOS/GoogleAnalytics/GoogleAnalyticsPlugin.m
@@ -55,19 +55,23 @@ static const NSInteger kGANDispatchPeriodSec = 10;
 	int index = [[options valueForKey:@"index"] intValue];
 	NSString* name = [options valueForKey:@"name"];
 	NSString* value = [options valueForKey:@"value"];
+    int scopeVal = [[options valueForKey:@"scope"] intValue];
+    GANCVScope scope = (scopeVal == 1) ? kGANVisitorScope : (scopeVal == 2) ? kGANSessionScope : kGANPageScope;
+    
     
 	NSError *error;
     
 	if (![[GANTracker sharedTracker] setCustomVariableAtIndex:index 
                                                          name:name 
                                                         value:value 
+                                                        scope:scope
                                                     withError:&error]) {
 		// Handle error here
 		NSLog(@"GoogleAnalyticsPlugin.setCustonVariable Error::%@",[error localizedDescription]);
 	}
     
     
-	NSLog(@"GoogleAnalyticsPlugin.setCustomVariable::%d, %@, %@", index, name, value);
+	NSLog(@"GoogleAnalyticsPlugin.setCustomVariable::%d, %@, %@, %d", index, name, value, scope);
     
 }
 


### PR DESCRIPTION
In recent versions, browser history is retained across instances of ChildBrowser. Opening a second ChildBrowser, after closing a previous instance, results in the user being able to navigate back through the history of the previous CB instance.

For those who want a fresh, history-free experience in each CB instance, you can use the clear() method in the onClose callback:

``` javascript
window.cb.onClose = function(){ window.cb.clear(); };
```

or by passing a boolean true to the close() method:

``` javascript
window.cb.close(true);
```
