### PR TITLE
[iOS] ChildBrowser: add .clear() method to flush CB history

### DIFF
--- a/iOS/ChildBrowser/ChildBrowser.js
+++ b/iOS/ChildBrowser/ChildBrowser.js
@@ -50,9 +50,16 @@ ChildBrowser.prototype.showWebPage = function(loc)
 };
 
 // close the browser, will NOT result in close callback
-ChildBrowser.prototype.close = function()
+ChildBrowser.prototype.close = function(clearInst)
 {
     cordovaRef.exec("ChildBrowserCommand.close");
+    if(clearInst) window.plugins.childBrowser.clear();
+};
+
+// clear the browser instance/history
+ChildBrowser.prototype.clear = function()
+{
+    cordovaRef.exec("ChildBrowserCommand.clear");
 };
 
 // Not Implemented

--- a/iOS/ChildBrowser/ChildBrowserCommand.m
+++ b/iOS/ChildBrowser/ChildBrowserCommand.m
@@ -54,6 +54,11 @@
     [self.childBrowser closeBrowser];
 }
 
+- (void)clear:(NSMutableArray*)arguments withDict:(NSMutableDictionary*)options
+{    
+    self.childBrowser = nil;
+}
+
 - (void)onClose
 {
     [self.webView stringByEvaluatingJavaScriptFromString:@"window.plugins.childBrowser.onClose();"];


### PR DESCRIPTION
In recent versions, browser history is retained across instances of ChildBrowser. Opening a second ChildBrowser, after closing a previous instance, results in the user being able to navigate back through the history of the previous CB instance.

For those who want a fresh, history-free experience in each CB instance, you can use the clear() method in the onClose callback:

``` javascript
window.cb.onClose = function(){ window.cb.clear(); };
```

or by passing a boolean true to the close() method:

``` javascript
window.cb.close(true);
```
