### PR TITLE
[iOS] GoogleAnalytics: support for setCustomVariable 'scope' parameter

### DIFF
--- a/iOS/GoogleAnalytics/GoogleAnalyticsPlugin.js
+++ b/iOS/GoogleAnalytics/GoogleAnalyticsPlugin.js
@@ -16,10 +16,11 @@ GoogleAnalyticsPlugin.prototype.trackEvent = function(category,action,label,valu
 	cordova.exec("GoogleAnalyticsPlugin.trackEvent",options);
 };
 
-GoogleAnalyticsPlugin.prototype.setCustomVariable = function(index,name,value) {
+GoogleAnalyticsPlugin.prototype.setCustomVariable = function(index,name,value,scope) {
 	var options = {index:index,
 		name:name,
-		value:value};
+		value:value,
+        scope:isNaN(parseInt(scope)) ? 3 : scope};  // page-level default
 	cordova.exec("GoogleAnalyticsPlugin.setCustomVariable",options);
 };
 

--- a/iOS/GoogleAnalytics/GoogleAnalyticsPlugin.m
+++ b/iOS/GoogleAnalytics/GoogleAnalyticsPlugin.m
@@ -55,19 +55,23 @@ static const NSInteger kGANDispatchPeriodSec = 10;
 	int index = [[options valueForKey:@"index"] intValue];
 	NSString* name = [options valueForKey:@"name"];
 	NSString* value = [options valueForKey:@"value"];
+    int scopeVal = [[options valueForKey:@"scope"] intValue];
+    GANCVScope scope = (scopeVal == 1) ? kGANVisitorScope : (scopeVal == 2) ? kGANSessionScope : kGANPageScope;
+    
     
 	NSError *error;
     
 	if (![[GANTracker sharedTracker] setCustomVariableAtIndex:index 
                                                          name:name 
                                                         value:value 
+                                                        scope:scope
                                                     withError:&error]) {
 		// Handle error here
 		NSLog(@"GoogleAnalyticsPlugin.setCustonVariable Error::%@",[error localizedDescription]);
 	}
     
     
-	NSLog(@"GoogleAnalyticsPlugin.setCustomVariable::%d, %@, %@", index, name, value);
+	NSLog(@"GoogleAnalyticsPlugin.setCustomVariable::%d, %@, %@, %d", index, name, value, scope);
     
 }
 


### PR DESCRIPTION
Adds support for the optional setCustomVariable "scope" parameter. This achieves parity with the Android/Analytics implementation.

Google Analytics setCustomVariable docs here: https://developers.google.com/analytics/devguides/collection/gajs/gaTrackingCustomVariables
