### PR TITLE
iPhone/ClipboardPlugin: add link to a repository which includes version compatible with Phonegap >=  2.0.0

### DIFF
--- a/iPhone/ClipboardPlugin/README.md
+++ b/iPhone/ClipboardPlugin/README.md
@@ -1,5 +1,13 @@
 # PhoneGap ClipboardPlugin #
 by Michel Weimerskirch
+Ported to Phonegap 2.0 by Jacob Robbins
+
+This plugin gives access to Copy & Paste methods of the iOS Clipboard.
+
+Repository including version for Phonegap 2.0 is located at: https://github.com/jacob/ClipboardPlugin
+
+
+
 
 ## Adding the Plugin to your project ##
 


### PR DESCRIPTION
I have ported the iOS ClipboardPlugin under the iPhone directory to work with Phonegap 2.0.0 and above. Added a link to the external repository with the ported version of the plugin.
