### PR TITLE
add "clearAllCache" option (all cookies) to Childbrowser plugin

### DIFF
--- a/Android/ChildBrowser/2.0.0/src/com/phonegap/plugins/childBrowser/ChildBrowser.java
+++ b/Android/ChildBrowser/2.0.0/src/com/phonegap/plugins/childBrowser/ChildBrowser.java
@@ -55,7 +55,7 @@ public class ChildBrowser extends Plugin {
     private WebView webview;
     private EditText edittext;
     private boolean showLocationBar = true;
-
+    private boolean clearAllCache = false;
     /**
      * Executes the request and returns PluginResult.
      *
@@ -211,6 +211,7 @@ public class ChildBrowser extends Plugin {
         // Determine if we should hide the location bar.
         if (options != null) {
             showLocationBar = options.optBoolean("showLocationBar", true);
+            clearAllCache = options.optBoolean("clearAllCache", false);
         }
 
         // Create dialog in new thread
@@ -355,6 +356,10 @@ public class ChildBrowser extends Plugin {
                 settings.setBuiltInZoomControls(true);
                 settings.setPluginsEnabled(true);
                 settings.setDomStorageEnabled(true);
+                if(clearAllCache){
+                    Log.v(LOG_TAG,"clear cache request detected");
+                    CookieManager.getInstance().removeAllCookie();
+                }
                 webview.loadUrl(url);
                 webview.setId(6);
                 webview.getSettings().setLoadWithOverviewMode(true);

--- a/Android/ChildBrowser/README.md
+++ b/Android/ChildBrowser/README.md
@@ -37,7 +37,7 @@ Note that unlike the iphone version, android childbrowser doesn't require a call
     * This method loads up a new web view in a dialog.
     *
     * @param url           The url to load
-    * @param options       An object that specifies additional options
+    * @param options       An object that specifies additional options (showLocationBar, clearAllCache)
     */
   showWebPage(url, [options])
 </pre>


### PR DESCRIPTION
it is small patch concerning this issue: https://github.com/phonegap/phonegap-plugins/issues/563
#### Sample usage: In your own app's javascript file

```
 window.plugins.childBrowser.showWebPage("http://www.google.com", {  clearAllCache: true });
```

since it is my first time doing pulling request, please let me know if there is a specific format or if any further information is required.
