### PR TITLE
Updated Android/Diagnostic for Cordova 2+ Compatibility

### DIFF
--- a/Android/Diagnostic/README.md
+++ b/Android/Diagnostic/README.md
@@ -39,7 +39,7 @@ Using this plugin requires a PhoneGap project for Android: [Get Started Guide](h
 The plugin creates the object:
 
 <pre>
- window.plugins.diagnostic
+ window.Diagnostic
 </pre>
 To use, call one of the following, available methods:
 
@@ -61,7 +61,7 @@ isLocationEnabled()
 Usage:
 
 <pre>
-   window.plugins.diagnostic.isLocationEnabled(locationEnabledSuccessCallback, locationEnabledErrorCallback);
+   window.Diagnostic.isLocationEnabled(locationEnabledSuccessCallback, locationEnabledErrorCallback);
 
    function locationEnabledSuccessCallback(result) {
       if (result)
@@ -88,7 +88,7 @@ Usage:
 
 <pre>
    alert("You must enable the location services in device settings.");
-   window.plugins.diagnostic.switchToLocationSettings();
+   window.Diagnostic.switchToLocationSettings();
 </pre>
 
 - isGpsEnabled:
@@ -108,7 +108,7 @@ isGpsEnabled()
 Usage:
 
 <pre>
-   window.plugins.diagnostic.isGpsEnabled(gpsEnabledSuccessCallback, gpsEnabledErrorCallback);
+   window.Diagnostic.isGpsEnabled(gpsEnabledSuccessCallback, gpsEnabledErrorCallback);
 
    function gpsEnabledSuccessCallback(result) {
       if (result)
@@ -139,7 +139,7 @@ isWirelessNetworkLocationEnabled()
 Usage:
 
 <pre>
-   window.plugins.diagnostic.isWirelessNetworkLocationEnabled(wirelessNetworkLocationEnabledSuccessCallback, wirelessNetworkLocationEnabledErrorCallback);
+   window.Diagnostic.isWirelessNetworkLocationEnabled(wirelessNetworkLocationEnabledSuccessCallback, wirelessNetworkLocationEnabledErrorCallback);
 
    function wirelessNetworkLocationEnabledSuccessCallback(result) {
 	  if (result)
@@ -170,7 +170,7 @@ isWifiEnabled()
 Usage:
 
 <pre>
-   window.plugins.diagnostic.isWifiEnabled(wifiEnabledSuccessCallback, wifiEnabledErrorCallback);
+   window.Diagnostic.isWifiEnabled(wifiEnabledSuccessCallback, wifiEnabledErrorCallback);
 
    function wifiEnabledSuccessCallback(result) {
 	  if (result)
@@ -197,7 +197,7 @@ Usage:
 
 <pre>
    alert("You must enable the Wi-Fi in device settings.");
-   window.plugins.diagnostic.switchToWifiSettings();
+   window.Diagnostic.switchToWifiSettings();
 </pre>
 
 - isBluetoothEnabled:
@@ -217,7 +217,7 @@ isBluetoothEnabled()
 Usage:
 
 <pre>
-   window.plugins.diagnostic.isBluetoothEnabled(bluetoothEnabledSuccessCallback, bluetoothEnabledErrorCallback);
+   window.Diagnostic.isBluetoothEnabled(bluetoothEnabledSuccessCallback, bluetoothEnabledErrorCallback);
 
    function bluetoothEnabledSuccessCallback(result) {
 	  if (result)
@@ -244,7 +244,7 @@ Usage:
 
 <pre>
    alert("You must enable the Bluetooth in device settings.");
-   window.plugins.diagnostic.switchToBluetoothSettings();
+   window.Diagnostic.switchToBluetoothSettings();
 </pre>
 
 

--- a/Android/Diagnostic/src/net/avantic/diagnosticPlugin/Diagnostic.java
+++ b/Android/Diagnostic/src/net/avantic/diagnosticPlugin/Diagnostic.java
@@ -19,8 +19,8 @@ import android.os.Looper;
 import android.provider.Settings;
 import android.util.Log;
 
-import com.phonegap.api.Plugin;
-import com.phonegap.api.PluginResult;
+import org.apache.cordova.api.Plugin;
+import org.apache.cordova.api.PluginResult;
 
 public class Diagnostic extends Plugin {
 

--- a/Android/Diagnostic/www/diagnostic.js
+++ b/Android/Diagnostic/www/diagnostic.js
@@ -124,6 +124,4 @@ Diagnostic.prototype.switchToBluetoothSettings = function() {
 						[]);
 };
 
-cordova.addConstructor(function() {
-	cordova.addPlugin("diagnostic", new Diagnostic());
-});
+window.Diagnostic = new Diagnostic();

--- a/Android/Diagnostic/www/diagnostic.js
+++ b/Android/Diagnostic/www/diagnostic.js
@@ -3,125 +3,127 @@
  *
  *  Copyright (c) 2012 AVANTIC ESTUDIO DE INGENIEROS
  *  
-**/
+ **/
 
+(function() {
+	var Diagnostic = function() {
+	};
 
-var Diagnostic = function() {
-};
+	/**
+	 * Checks device settings for location.
+	 *
+	 * @param successCallback		The callback which will be called when diagnostic of location is successful.
+	 * 								This callback function have a boolean param with the diagnostic result.
+	 * @param errorCallback			The callback which will be called when diagnostic of location encounters an error.
+	 * 								This callback function have a string param with the error.
+	 */
+	Diagnostic.prototype.isLocationEnabled = function(successCallback, errorCallback) {
+		return cordova.exec(successCallback,
+			errorCallback,
+			'Diagnostic',
+			'isLocationEnabled',
+			[]);
+	};
 
+	/**
+	 * Requests that the user enable the location services in device settings.
+	 */
+	Diagnostic.prototype.switchToLocationSettings = function() {
+		return cordova.exec(null,
+			null,
+			'Diagnostic',
+			'switchToLocationSettings',
+			[]);
+	};
 
-/**
- * Checks device settings for location.
- *
- * @param successCallback		The callback which will be called when diagnostic of location is successful.
- * 								This callback function have a boolean param with the diagnostic result.
- * @param errorCallback			The callback which will be called when diagnostic of location encounters an error.
- * 								This callback function have a string param with the error.
- */
-Diagnostic.prototype.isLocationEnabled = function(successCallback, errorCallback) {
-	return cordova.exec(successCallback,
-						errorCallback,
-						'Diagnostic',
-						'isLocationEnabled',
-						[]);
-};
+	/**
+	 * Checks device settings for GPS.
+	 *
+	 * @param successCallback		The callback which will be called when diagnostic of GPS is successful.
+	 * 								This callback function have a boolean param with the diagnostic result.
+	 * @param errorCallback			The callback which will be called when diagnostic of GPS encounters an error.
+	 * 								This callback function have a string param with the error.
+	 */
+	Diagnostic.prototype.isGpsEnabled = function(successCallback, errorCallback) {
+		return cordova.exec(successCallback,
+			errorCallback,
+			'Diagnostic',
+			'isGpsEnabled',
+			[]);
+	};
 
-/**
- * Requests that the user enable the location services in device settings.
- */
-Diagnostic.prototype.switchToLocationSettings = function() {
-	return cordova.exec(null,
-						null,
-						'Diagnostic',
-						'switchToLocationSettings',
-						[]);
-};
+	/**
+	 * Checks device settings for wireless network location (Wi-Fi and/or mobile networks).
+	 *
+	 * @param successCallback		The callback which will be called when diagnostic of wireless network location is successful.
+	 * 								This callback function have a boolean param with the diagnostic result.
+	 * @param errorCallback			The callback which will be called when diagnostic of wireless network location encounters an error.
+	 * 								This callback function have a string param with the error.
+	 */
+	Diagnostic.prototype.isWirelessNetworkLocationEnabled = function(successCallback, errorCallback) {
+		return cordova.exec(successCallback,
+			errorCallback,
+			'Diagnostic',
+			'isWirelessNetworkLocationEnabled',
+			[]);
+	};
 
-/**
- * Checks device settings for GPS.
- *
- * @param successCallback		The callback which will be called when diagnostic of GPS is successful.
- * 								This callback function have a boolean param with the diagnostic result.
- * @param errorCallback			The callback which will be called when diagnostic of GPS encounters an error.
- * 								This callback function have a string param with the error.
- */
-Diagnostic.prototype.isGpsEnabled = function(successCallback, errorCallback) {
-	return cordova.exec(successCallback,
-						errorCallback,
-						'Diagnostic',
-						'isGpsEnabled',
-						[]);
-};
+	/**
+	 * Checks device settings for Wi-Fi.
+	 *
+	 * @param successCallback		The callback which will be called when diagnostic of Wi-Fi is successful.
+	 * 								This callback function have a boolean param with the diagnostic result.
+	 * @param errorCallback			The callback which will be called when diagnostic of Wi-Fi encounters an error.
+	 * 								This callback function have a string param with the error.
+	 */
+	Diagnostic.prototype.isWifiEnabled = function(successCallback, errorCallback) {
+		return cordova.exec(successCallback,
+			errorCallback,
+			'Diagnostic',
+			'isWifiEnabled',
+			[]);
+	};
 
-/**
- * Checks device settings for wireless network location (Wi-Fi and/or mobile networks).
- *
- * @param successCallback		The callback which will be called when diagnostic of wireless network location is successful.
- * 								This callback function have a boolean param with the diagnostic result.
- * @param errorCallback			The callback which will be called when diagnostic of wireless network location encounters an error.
- * 								This callback function have a string param with the error.
- */
-Diagnostic.prototype.isWirelessNetworkLocationEnabled = function(successCallback, errorCallback) {
-	return cordova.exec(successCallback,
-						errorCallback,
-						'Diagnostic',
-						'isWirelessNetworkLocationEnabled',
-						[]);
-};
+	/**
+	 * Requests that the user enable the Wi-Fi in device settings.
+	 */
+	Diagnostic.prototype.switchToWifiSettings = function() {
+		return cordova.exec(null,
+			null,
+			'Diagnostic',
+			'switchToWifiSettings',
+			[]);
+	};
 
-/**
- * Checks device settings for Wi-Fi.
- *
- * @param successCallback		The callback which will be called when diagnostic of Wi-Fi is successful.
- * 								This callback function have a boolean param with the diagnostic result.
- * @param errorCallback			The callback which will be called when diagnostic of Wi-Fi encounters an error.
- * 								This callback function have a string param with the error.
- */
-Diagnostic.prototype.isWifiEnabled = function(successCallback, errorCallback) {
-	return cordova.exec(successCallback,
-						errorCallback,
-						'Diagnostic',
-						'isWifiEnabled',
-						[]);
-};
+	/**
+	 * Checks device settings for bluetooth.
+	 *
+	 * @param successCallback		The callback which will be called when diagnostic of bluetooth is successful.
+	 * 								This callback function have a boolean param with the diagnostic result.
+	 * @param errorCallback			The callback which will be called when diagnostic of bluetooth encounters an error.
+	 * 								This callback function have a string param with the error.
+	 */
+	Diagnostic.prototype.isBluetoothEnabled = function(successCallback, errorCallback) {
+		return cordova.exec(successCallback,
+			errorCallback,
+			'Diagnostic',
+			'isBluetoothEnabled',
+			[]);
+	};
 
-/**
- * Requests that the user enable the Wi-Fi in device settings.
- */
-Diagnostic.prototype.switchToWifiSettings = function() {
-	return cordova.exec(null,
-						null,
-						'Diagnostic',
-						'switchToWifiSettings',
-						[]);
-};
+	/**
+	 * Requests that the user enable the bluetooth in device settings.
+	 */
+	Diagnostic.prototype.switchToBluetoothSettings = function() {
+		return cordova.exec(null,
+			null,
+			'Diagnostic',
+			'switchToBluetoothSettings',
+			[]);
+	};
 
-/**
- * Checks device settings for bluetooth.
- *
- * @param successCallback		The callback which will be called when diagnostic of bluetooth is successful.
- * 								This callback function have a boolean param with the diagnostic result.
- * @param errorCallback			The callback which will be called when diagnostic of bluetooth encounters an error.
- * 								This callback function have a string param with the error.
- */
-Diagnostic.prototype.isBluetoothEnabled = function(successCallback, errorCallback) {
-	return cordova.exec(successCallback,
-						errorCallback,
-						'Diagnostic',
-						'isBluetoothEnabled',
-						[]);
-};
- 
-
-/**
- * Requests that the user enable the bluetooth in device settings.
- */
-Diagnostic.prototype.switchToBluetoothSettings = function() {
-	return cordova.exec(null,
-						null,
-						'Diagnostic',
-						'switchToBluetoothSettings',
-						[]);
-};
-
-window.Diagnostic = new Diagnostic();
+	document.addEventListener('deviceready', function() {
+		window.Diagnostic = new Diagnostic();
+	});
+	
+})();

--- a/Android/Diagnostic/www/diagnostic.js
+++ b/Android/Diagnostic/www/diagnostic.js
@@ -124,4 +124,4 @@ Diagnostic.prototype.switchToBluetoothSettings = function() {
 						[]);
 };
 
-window.Diagnostic = new Diagnostic();
+window.Diagnostic = cordova.exec ? new Diagnostic() : undefined;


### PR DESCRIPTION
Needed the Diagnostic Plugin, currently using 2.3, therefore i had to make those quick fixes.

They make is work, javascript was simply changed as per [this stackoverflow article](http://stackoverflow.com/questions/11613274/window-plugins-undefined-in-cordova-2-0-0#11621631).

I understand that sometime in the near future it would also be required that Diagnostic.java would need to be changed to extend `CordovaPlugin` directly - but at least this fix makes the plugin catch up with the 2.0 series.
