### PR TITLE
SMS Sending Plugin for Android, working with Phonegap 2.5

### DIFF
--- a/Android/SMSSendingPlugin/README.md
+++ b/Android/SMSSendingPlugin/README.md
@@ -1,0 +1,73 @@
+SMS Sending plugin for Phonegap
+===============================
+By Pierre-Yves Orban
+
+This Android Phonegap plugin allows you to easily send SMS (using the native SMS Manager instead of the default SMS app)
+Works with Phonegap 2.x
+This plugin was successfully tested with Phonegap 2.5 and Android 4.2.2 (on a Samsung Galaxy Nexus device).
+
+## Adding this plugin to your project ##
+0. (Make sure you are using Phonegap > 2.0)
+1. Move SmsSendingPlugin.js to your project's www folder and include a reference to it in your html files. 
+2. Add the java file from src to your project's src hierarchy
+3. Reference the plugin in your res/config.xml file
+<plugin name="SendSmsPlugin" value="org.apache.cordova.plugin.SendSmsPlugin"/>
+4. Ensure that your manifest contains the necessary permissions to send SMS messages:
+
+<uses-permission android:name="android.permission.SEND_SMS"/>
+<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+## Using the plugin ##
+To instantiate the plugin object:
+```javascript
+var smsSendingPlugin = cordova.require('cordova/plugin/smssendingplugin');
+```
+
+### isSupported ###
+Check if the SMS technology is supported by the device. For example:
+
+```javascript
+  smsSendingPlugin.isSupported ((function(supported) {
+    if(supported) 
+      alert("SMS supported !");
+    else
+      alert("SMS not supported");
+  }), function() {
+    alert("Error while checking the SMS support");
+  });
+```
+
+### send ###
+Send an SMS message.  For example:
+
+```javascript
+  smsSendingPlugin.send ("0032472345678", "Hello World !", function() {
+    alert("Message sent :-)");
+  }, function() {
+    alert("Message not sent :s");
+  });
+```
+  
+## Licence ##
+
+The MIT License
+
+Copyright (c) 2013 Pierre-Yves Orban
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Android/SMSSendingPlugin/assets/www/SmsSendingPlugin.js
+++ b/Android/SMSSendingPlugin/assets/www/SmsSendingPlugin.js
@@ -1,0 +1,42 @@
+/*
+Copyright (C) 2011 by Pierre-Yves Orban
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+cordova.define("cordova/plugin/smssendingplugin", function(require, exports, module) {
+  var exec = require('cordova/exec');
+  var SmsSendingPlugin = function() {};
+
+  /**
+   * Check if the device has a possibility to send and receive SMS
+   */
+  SmsSendingPlugin.prototype.isSupported = function(successCallback,failureCallback) {
+    return exec(successCallback, failureCallback, 'SmsSendingPlugin', 'HasSMSPossibility', []);
+  }
+  /**
+   * Send a message to the given phone number
+   */
+  SmsSendingPlugin.prototype.send = function(phone, message, successCallback,failureCallback) {
+    return exec(successCallback, failureCallback, 'SmsSendingPlugin', 'SendSMS', [phone, message]);
+  }
+
+  var smssendingplugin = new SmsSendingPlugin();
+  module.exports = smssendingplugin;
+});

--- a/Android/SMSSendingPlugin/src/org/apache/cordova/plugin/SmsSendingPlugin.java
+++ b/Android/SMSSendingPlugin/src/org/apache/cordova/plugin/SmsSendingPlugin.java
@@ -1,0 +1,82 @@
+/*
+Copyright (C) 2013 by Pierre-Yves Orban
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.apache.cordova.plugin;
+
+import org.apache.cordova.api.CallbackContext;
+import org.apache.cordova.api.CordovaPlugin;
+import org.apache.cordova.api.PluginResult;
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import android.app.Activity;
+import android.app.PendingIntent;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.telephony.SmsManager;
+
+public class SmsSendingPlugin extends CordovaPlugin {
+	public final String ACTION_HAS_SMS_POSSIBILITY = "HasSMSPossibility";
+	public final String ACTION_SEND_SMS = "SendSMS";
+	
+	private SmsManager smsManager = null;
+	
+	public SmsSendingPlugin() {
+		super();
+		smsManager = SmsManager.getDefault();
+	}
+	
+	@Override
+	public boolean execute(String action, JSONArray args,
+			final CallbackContext callbackContext) throws JSONException {
+		
+		if (action.equals(ACTION_HAS_SMS_POSSIBILITY)) {
+			
+			Activity ctx = this.cordova.getActivity();
+			if(ctx.getPackageManager().hasSystemFeature(PackageManager.FEATURE_TELEPHONY)){
+				callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, true));
+			} else {
+				callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, false));
+			}
+			return true;
+		}
+		else if (action.equals(ACTION_SEND_SMS)) {
+			try {
+				String phoneNumber = args.getString(0);
+				String message = args.getString(1);
+				this.sendSMS(phoneNumber, message);
+				
+				callbackContext.sendPluginResult(new PluginResult(
+						PluginResult.Status.OK));
+			}
+			catch (JSONException ex) {
+				callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR, ex.getMessage()));
+			}
+			return true;
+		}
+		return false;
+	}
+
+	private void sendSMS(String phoneNumber, String message) {
+        PendingIntent sentIntent = PendingIntent.getActivity(this.cordova.getActivity(), 0, new Intent(), 0);  
+		smsManager.sendTextMessage(phoneNumber, null, message, sentIntent, null);
+	}
+}


### PR DESCRIPTION
This plugin allows you to send SMS using the Android SMS Manager. 
It works with Phonegap 2.5 and has been successfully tested on Android 4.2.2
