### PR TITLE
Create a plugin that reports the available memory within an iOS device upon request

### DIFF
--- a/iOS/FreeMemory/FreeMemory.h
+++ b/iOS/FreeMemory/FreeMemory.h
@@ -1,0 +1,7 @@
+#import <Cordova/CDV.h>
+
+@interface FreeMemory : CDVPlugin
+
+- (void) getFreeMemory:(CDVInvokedUrlCommand*)command;
+
+@end

--- a/iOS/FreeMemory/FreeMemory.m
+++ b/iOS/FreeMemory/FreeMemory.m
@@ -1,0 +1,32 @@
+#import <mach/mach.h> 
+#import <mach/mach_host.h>
+
+#import "FreeMemory.h"
+#import <Cordova/CDV.h>
+
+
+@implementation FreeMemory
+- (NSUInteger)amountOfFreeMemory {
+    mach_port_t             host_port = mach_host_self();
+    mach_msg_type_number_t  host_size = sizeof(vm_statistics_data_t) / sizeof(integer_t);
+    vm_size_t               pagesize;
+    vm_statistics_data_t    vm_stat;
+    host_page_size(host_port, &pagesize);
+    if (host_statistics(host_port, HOST_VM_INFO, (host_info_t)&vm_stat, &host_size) != KERN_SUCCESS) NSLog(@"Failed to fetch vm statistics");
+    //natural_t   mem_used = (vm_stat.active_count + vm_stat.inactive_count + vm_stat.wire_count) * pagesize;
+    //natural_t   mem_total = mem_used + mem_free;
+    natural_t   mem_free = vm_stat.free_count * pagesize;
+    return mem_free;
+}
+
+
+
+
+- (void) getFreeMemory:(CDVInvokedUrlCommand*)command{
+    CDVPluginResult* pluginResult = nil;
+    NSUInteger freemem = [self amountOfFreeMemory];
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[NSString stringWithFormat:@"%d", freemem]];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+@end

--- a/iOS/FreeMemory/README.md
+++ b/iOS/FreeMemory/README.md
@@ -1,0 +1,45 @@
+# Cordova 2.1.0+ iOS Free Memory Report Plugin 
+
+Author: [Chris Williams](http://www.twitter.com/voodootikigod) (@voodootikigod)
+
+In the config.xml file, you need to add the plugin with the key/pair value of:
+
+<pre>
+ &lt;plugin name="FreeMemory" value="FreeMemory" />
+</pre>
+
+Also be sure to copy the FreeMemory.h and FreeMemory.m to your {PROJECT_ROOT}/{PROJECT_NAME}/Plugins directory and copy freememory.js to your {PROJECT_ROOT}/www directory.
+
+Include the JS file in your HTML as such:
+
+<pre>
+	&lt;script type="text/javascript" src="freememory.js"></script>
+</pre>
+
+
+To Get the Current Available Memory on demand, use the following:
+
+<pre>
+window.freeMemory(function(details) {
+    sys.freeMemory = (details);
+});
+</pre>
+
+Bear in mind, this is the free memory within the device (total), not necessarily the available memory just to your application. It should assist, though, with identifying slow leaks and performance.
+
+
+
+--
+
+
+License
+
+The MIT License
+
+Copyright (c) 2013 [Chris Williams](http://www.twitter.com/voodootikigod) (@voodootikigod)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/iOS/FreeMemory/README.md
+++ b/iOS/FreeMemory/README.md
@@ -1,0 +1,45 @@
+# Cordova 2.1.0+ iOS Free Memory Report Plugin 
+
+Author: Chris Williams (@voodootikigod)
+
+In the config.xml file, you need to add the plugin with the key/pair value of:
+
+<code>
+<plugin name="FreeMemory" value="FreeMemory" />
+</code>
+
+Also be sure to copy the FreeMemory.h and FreeMemory.m to your {PROJECT_ROOT}/{PROJECT_NAME}/Plugins directory and copy freememory.js to your {PROJECT_ROOT}/www directory.
+
+Include the JS file in your HTML as such:
+
+<code>
+	<script type="text/javascript" src="freememory.js"></script>
+</code>
+
+
+To Get the Current Available Memory on demand, use the following:
+
+<code>
+window.freeMemory(function(details) {
+    sys.freeMemory = (details);
+});
+</code>
+
+Bear in mind, this is the free memory within the device (total), not necessarily the available memory just to your application. It should assist, though, with identifying slow leaks and performance.
+
+
+
+--
+
+
+License
+
+The MIT License
+
+Copyright (c) 2013 Chris Williams (@voodootikigod)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/iOS/FreeMemory/freememory.js
+++ b/iOS/FreeMemory/freememory.js
@@ -1,0 +1,5 @@
+window.freeMemory = function(callback) {
+    cordova.exec(callback, function(err) {
+                 callback('Could not get Free Memory.');
+         }, "FreeMemory", "getFreeMemory", []);
+};


### PR DESCRIPTION
This plugin can be helpful for detecting slow memory leaks in production and other systems where the use of instruments is not easy to accomplish.
