### PR TITLE
Changed DLog to NSLog

### DIFF
--- a/iOS/EmailComposerWithAttachments/EmailComposer.m
+++ b/iOS/EmailComposerWithAttachments/EmailComposer.m
@@ -115,7 +115,7 @@
                     counter++;
                 }
                 @catch (NSException *exception) {
-                    DLog(@"Cannot attach file at path %@; error: %@", path, exception);
+                    NSLog(@"Cannot attach file at path %@; error: %@", path, exception);
                 }
             }
         }


### PR DESCRIPTION
I have changed DLog to NSLog for out-of-the-box compatibility with an Xcode project. Otherwise it wouldn't compile in a freshly minted ios project created by phonegap-2.6.0.
