### PR TITLE
Import CDVJSON.h for PhoneGap 2.7

### DIFF
--- a/iOS/Twitter/TwitterPlugin.m
+++ b/iOS/Twitter/TwitterPlugin.m
@@ -6,7 +6,7 @@
 //
 
     #import "TwitterPlugin.h"
-    #import <Cordova/JSONKit.h>
+    #import <CORDOVA/CDVJSON.h>
 	#import <Cordova/CDVAvailability.h>
 
 #define TWITTER_URL @"http://api.twitter.com/1/"


### PR DESCRIPTION
In PhoneGap 2.7, importing Cordova/JSONKit.h causes the build to fail.
