### PR TITLE
Migration of DatePicker iOS plugin to work with Cordova/PhoneGap 3

### DIFF
--- a/iOS/DatePicker/3.0.0/README.md
+++ b/iOS/DatePicker/3.0.0/README.md
@@ -1,0 +1,2 @@
+# Migration to work with Cordova/PhoneGap 3
+https://github.com/sectore/phonegap3-ios-datepicker-plugin


### PR DESCRIPTION
Just adding a README file to link to the [updated version](https://github.com/sectore/phonegap3-ios-datepicker-plugin) of DatePicker iOS plugin to work with Cordova/PhoneGap 3

Thanks!

-Jens
