### PR TITLE
Cancel notications before unpersisting

### DIFF
--- a/Android/LocalNotification/LocalNotification.java
+++ b/Android/LocalNotification/LocalNotification.java
@@ -56,8 +56,9 @@ public class LocalNotification extends Plugin {
 	    unpersistAlarm(alarmId);
 	    return this.cancelNotification(alarmId);
 	} else if (action.equalsIgnoreCase("cancelall")) {
+	    PluginResult result = this.cancelAllNotifications();
 	    unpersistAlarmAll();
-	    return this.cancelAllNotifications();
+	    return result;
 	}
 
 	return result;


### PR DESCRIPTION
This is a bugfix. Since alarms were being unpersisted before canceled, there was nothing to cancel.
